### PR TITLE
Add profiler.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,3 +18,7 @@ cranelift-native = "0.80.0"
 
 [profile.release]
 opt-level = 3
+
+[profile.bench]
+opt-level = 3
+debug = 2

--- a/profiler/Cargo.toml
+++ b/profiler/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "profiler"
+version = "0.1.0"
+edition = "2021"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+hovm = { path = "../" }
+pprof = { version = "0.4", features = ["flamegraph", "protobuf"] }
+
+[profile.bench]
+opt-level = 3
+debug = 2

--- a/profiler/README.md
+++ b/profiler/README.md
@@ -1,0 +1,18 @@
+Profiling
+---------
+
+#### 1. Install Dependencies
+
+These are optional dependencies to generate the flowchart output (the flamegraph output doesn't require them):
+
+* [pprof](https://github.com/google/pprof)
+* [GraphViz](https://graphviz.org/)
+
+#### 2. Profile
+
+In a shell, run:
+```sh
+cargo run --profile bench   # To generate the flamegraph and protobuf outputs.
+# And optionally:
+pprof -svg profile.pb # To generate the flowchart from the protobuf output.
+```

--- a/profiler/src/main.rs
+++ b/profiler/src/main.rs
@@ -1,0 +1,32 @@
+use hovm::builder;
+use pprof::protos::Message;
+use std::{fs::File, io::Write};
+
+fn main() {
+  let guard = pprof::ProfilerGuard::new(100).unwrap();
+  let code = "
+    //(Main) = (λf λx (f (f x)) λf λx (f (f x)))
+    (Slow (Z))      = 1
+    (Slow (S pred)) = (+ (Slow pred) (Slow pred))
+    
+    (Main) = (Slow (S(S (S(S(S(S (S(S(S(S (S(S(S(S (S(S(S(S (S(S(S(S (S(S(S(S (Z) )))) )))) )))) )))) )))) )))) )) )
+  ";
+  let (norm, cost, size, time) = builder::eval_code("Main", code);
+  println!("Rewrites: {} ({:.2} MR/s)", cost, (cost as f64) / (time as f64) / 1000.0);
+  println!("Mem.Size: {}", size);
+  println!();
+  println!("{}", norm);
+  if let Ok(report) = guard.report().build() {
+    // Output flamegraph.
+    let file = File::create("flamegraph.svg").unwrap();
+    report.flamegraph(file).unwrap();
+
+    // Output protobuf.
+    let mut file = File::create("profile.pb").unwrap();
+    let profile = report.pprof().unwrap();
+
+    let mut content = Vec::new();
+    profile.encode(&mut content).unwrap();
+    file.write_all(&content).unwrap();
+  };
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,0 +1,14 @@
+#![allow(dead_code)]
+#![allow(unused_variables)]
+#![allow(unused_parens)]
+#![allow(non_snake_case)]
+#![allow(unused_imports)]
+#![allow(unused_mut)]
+
+pub mod builder;
+pub mod compiler;
+mod language;
+mod parser;
+mod readback;
+mod rulebook;
+mod runtime;

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,13 +5,7 @@
 #![allow(unused_imports)]
 #![allow(unused_mut)]
 
-mod builder;
-mod compiler;
-mod language;
-mod parser;
-mod readback;
-mod rulebook;
-mod runtime;
+use hovm::{builder, compiler};
 
 fn main() -> std::io::Result<()> {
   run_cli()?;


### PR DESCRIPTION
Todo:
 - [ ] Add output generation dependencies to dev shell.
 - [ ] Add a CLI to parameterise input programs.

Not sure how useful this will be, in any case, here's some example outputs:

![flamegraph](https://user-images.githubusercontent.com/18732253/150957477-f9ec19fa-7f7f-43c0-921b-78fee89a78e8.svg)

![profile001](https://user-images.githubusercontent.com/18732253/150957516-41fbdfb1-8cd6-4594-b19b-bb4dbbafb4dc.svg)

They're supposed to show which parts of the code the programs spends the most time on. E.g., with the above outputs, they show that least 25% of running time was spent on calls to `builder::alloc_body` so we might want to try to further optimise that part of the code.

It's a bit weird that it only seems to show one path through the code though (I don't see any of the other functions that should be making up the other 75% of the running time). Not sure if that's because my code is whack (this is most likely), or due to some limitation of pprof-rs, or because of the input hovm code I used.

Edit: Ah it seems like uploading to GitHub broke the interactivity of the SVGs. Well anyway, they're also supposed to be interactive...