### PR TITLE
compiler: switch to token replacement instead of format strings

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,18 +3,6 @@
 version = 3
 
 [[package]]
-name = "anyhow"
-version = "1.0.53"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94a45b455c14666b85fc40a019e8ab9eb75e3a124e05494f5397122bc9eb06e0"
-
-[[package]]
-name = "bitflags"
-version = "1.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
-
-[[package]]
 name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -89,45 +77,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "cranelift-jit"
-version = "0.80.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e0f0e20dbcac1e6c3caef955e004598a9a6a5f310e591e2c629ec15c7fa6bfa"
-dependencies = [
- "anyhow",
- "cranelift-codegen",
- "cranelift-entity",
- "cranelift-module",
- "cranelift-native",
- "libc",
- "log",
- "region",
- "target-lexicon",
- "winapi",
-]
-
-[[package]]
-name = "cranelift-module"
-version = "0.80.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93460fc789770f2a63163bfb5f2b851635ce29d91526f2e96854bcc4ed53a778"
-dependencies = [
- "anyhow",
- "cranelift-codegen",
-]
-
-[[package]]
-name = "cranelift-native"
-version = "0.80.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "166028ca0343a6ee7bddac0e70084e142b23f99c701bd6f6ea9123afac1a7a46"
-dependencies = [
- "cranelift-codegen",
- "libc",
- "target-lexicon",
-]
-
-[[package]]
 name = "hermit-abi"
 version = "0.1.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -141,9 +90,6 @@ name = "hvm"
 version = "0.1.0"
 dependencies = [
  "cranelift",
- "cranelift-jit",
- "cranelift-module",
- "cranelift-native",
  "num_cpus",
 ]
 
@@ -160,15 +106,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "51b9bbe6c47d51fc3e1a9b945965946b4c44142ab8792c50835a980d362c2710"
 dependencies = [
  "cfg-if",
-]
-
-[[package]]
-name = "mach"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b823e83b2affd8f40a9ee8c29dbc56404c1e34cd2710921f2801e2cf29527afa"
-dependencies = [
- "libc",
 ]
 
 [[package]]
@@ -193,18 +130,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "region"
-version = "2.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "877e54ea2adcd70d80e9179344c97f93ef0dffd6b03e1f4529e6e83ab2fa9ae0"
-dependencies = [
- "bitflags",
- "libc",
- "mach",
- "winapi",
-]
-
-[[package]]
 name = "rustc-hash"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -221,25 +146,3 @@ name = "target-lexicon"
 version = "0.12.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9bffcddbc2458fa3e6058414599e3c838a022abae82e5c67b4f7f80298d5bff"
-
-[[package]]
-name = "winapi"
-version = "0.3.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
-dependencies = [
- "winapi-i686-pc-windows-gnu",
- "winapi-x86_64-pc-windows-gnu",
-]
-
-[[package]]
-name = "winapi-i686-pc-windows-gnu"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
-
-[[package]]
-name = "winapi-x86_64-pc-windows-gnu"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,9 +9,6 @@ edition = "2018"
 
 [dependencies]
 cranelift = "0.80.0"
-cranelift-jit = "0.80.0"
-cranelift-module = "0.80.0"
-cranelift-native = "0.80.0"
 num_cpus = "1.13.1"
 
 [profile.dev]

--- a/src/compiler.rs
+++ b/src/compiler.rs
@@ -453,14 +453,55 @@ pub fn c_runtime_template(
   id2nm: &str,
   names_count: u64,
 ) -> String {
-  let num_threads = num_cpus::get();
-  return format!(
-    include_str!("runtime.c"),
-    num_threads=num_threads,
-    c_ids = c_ids,
-    inits = inits,
-    codes = codes,
-    names_count = names_count,
-    id2nm = id2nm
+  const C_RUNTIME_TEMPLATE: &str = include_str!("runtime.c");
+  const C_CONSTRUCTOR_IDS_CONTENT: &str = "/* GENERATED_CONSTRUCTOR_IDS_CONTENT */";
+  const C_REWRITE_RULES_STEP_0_CONTENT: &str = "/* GENERATED_REWRITE_RULES_STEP_0_CONTENT */";
+  const C_REWRITE_RULES_STEP_1_CONTENT: &str = "/* GENERATED_REWRITE_RULES_STEP_1_CONTENT */";
+  const C_NAME_COUNT_CONTENT: &str = "/* GENERATED_NAME_COUNT_CONTENT */";
+  const C_ID_TO_NAME_DATA_CONTENT: &str = "/* GENERATED_ID_TO_NAME_DATA_CONTENT */";
+  const C_NUM_THREADS_CONTENT: &str = "/* GENERATED_NUM_THREADS_CONTENT */";
+
+  // Sanity checks: the generated section tokens we're looking for must be present in the runtime C
+  // file.
+  debug_assert!(
+    C_RUNTIME_TEMPLATE.contains(C_CONSTRUCTOR_IDS_CONTENT),
+    "The runtime C file is missing the constructor ids section token: {}",
+    C_CONSTRUCTOR_IDS_CONTENT
   );
+  debug_assert!(
+    C_RUNTIME_TEMPLATE.contains(C_REWRITE_RULES_STEP_0_CONTENT),
+    "The runtime C file is missing the rewrite rules step 0 section token: {}",
+    C_REWRITE_RULES_STEP_0_CONTENT
+  );
+  debug_assert!(
+    C_RUNTIME_TEMPLATE.contains(C_REWRITE_RULES_STEP_1_CONTENT),
+    "The runtime C file is missing the rewrite rules step 1 section token: {}",
+    C_REWRITE_RULES_STEP_1_CONTENT
+  );
+  debug_assert!(
+    C_RUNTIME_TEMPLATE.contains(C_NAME_COUNT_CONTENT),
+    "The runtime C file is missing name count section token: {}",
+    C_NAME_COUNT_CONTENT
+  );
+  debug_assert!(
+    C_RUNTIME_TEMPLATE.contains(C_ID_TO_NAME_DATA_CONTENT),
+    "The runtime C file is missing the id to name data section token: {}",
+    C_ID_TO_NAME_DATA_CONTENT
+  );
+  debug_assert!(
+    C_RUNTIME_TEMPLATE.contains(C_NUM_THREADS_CONTENT),
+    "The runtime C file is missing the num threads section token: {}",
+    C_NUM_THREADS_CONTENT
+  );
+
+  // Instantiate the template with the given sections' content
+  let runtime_template = C_RUNTIME_TEMPLATE
+    .replace(C_NUM_THREADS_CONTENT, &num_cpus::get().to_string())
+    .replace(C_CONSTRUCTOR_IDS_CONTENT, c_ids)
+    .replace(C_REWRITE_RULES_STEP_0_CONTENT, inits)
+    .replace(C_REWRITE_RULES_STEP_1_CONTENT, codes)
+    .replace(C_NAME_COUNT_CONTENT, &names_count.to_string())
+    .replace(C_ID_TO_NAME_DATA_CONTENT, id2nm);
+
+  runtime_template
 }

--- a/src/compiler.rs
+++ b/src/compiler.rs
@@ -362,14 +362,12 @@ pub fn compile_func_rule_term(
   let mut nams = 0;
   let mut vars: Vec<String> = vars
     .iter()
-    .map(|var @ bd::DynVar { param, field, erase }| {
-      match field {
-        Some(field) => {
-          format!("ask_arg(mem, ask_arg(mem, term, {}), {})", param, field)
-        }
-        None => {
-          format!("ask_arg(mem, term, {})", param)
-        }
+    .map(|var @ bd::DynVar { param, field, erase }| match field {
+      Some(field) => {
+        format!("ask_arg(mem, ask_arg(mem, term, {}), {})", param, field)
+      }
+      None => {
+        format!("ask_arg(mem, term, {})", param)
       }
     })
     .collect();

--- a/src/rulebook.rs
+++ b/src/rulebook.rs
@@ -586,15 +586,15 @@ pub fn flatten(rules: &Vec<lang::Rule>) -> Vec<lang::Rule> {
               }
               lang::Term::Var { .. } => {
                 println!("Sorry! HVM can't flatten this nested case:");
-                println!("");
+                println!();
                 println!("  {}", a);
-                println!("");
+                println!();
                 println!("Because of the argument '{}', in:", b_arg);
-                println!("");
+                println!();
                 println!("  {}", b);
-                println!("");
+                println!();
                 println!("This is a HVM limitation, and will be fixed in a future.");
-                println!("");
+                println!();
                 std::process::exit(1);
               }
               _ => {}

--- a/src/runtime.c
+++ b/src/runtime.c
@@ -33,7 +33,7 @@ const u64 U64_PER_GB = 0x8000000;
 const u64 HEAP_SIZE = 16 * U64_PER_GB * sizeof(u64);
 
 #ifdef PARALLEL
-#define MAX_WORKERS ({num_threads})
+#define MAX_WORKERS (/* GENERATED_NUM_THREADS_CONTENT */)
 #else
 #define MAX_WORKERS (1)
 #endif
@@ -86,24 +86,24 @@ const u64 GTN = 0xE;
 const u64 NEQ = 0xF;
 
 //GENERATED_CONSTRUCTOR_IDS_START//
-{c_ids}
+/* GENERATED_CONSTRUCTOR_IDS_CONTENT */
 //GENERATED_CONSTRUCTOR_IDS_END//
 
 // Threads
 // -------
 
-typedef struct {{
+typedef struct {
   u64 size;
   u64* data;
-}} Arr;
+} Arr;
 
-typedef struct {{
+typedef struct {
   u64* data;
   u64  size;
   u64  mcap;
-}} Stk;
+} Stk;
 
-typedef struct {{
+typedef struct {
   u64  tid;
   Lnk* node;
   u64  size;
@@ -121,7 +121,7 @@ typedef struct {{
 
   Thd  thread;
   #endif
-}} Worker;
+} Worker;
 
 // Globals
 // -------
@@ -131,185 +131,185 @@ Worker workers[MAX_WORKERS];
 // Array
 // -----
 
-void array_write(Arr* arr, u64 idx, u64 value) {{
+void array_write(Arr* arr, u64 idx, u64 value) {
   arr->data[idx] = value;
-}}
+}
 
-u64 array_read(Arr* arr, u64 idx) {{
+u64 array_read(Arr* arr, u64 idx) {
   return arr->data[idx];
-}}
+}
 
 // Stack
 // -----
 
 u64 stk_growth_factor = 16;
 
-void stk_init(Stk* stack) {{
+void stk_init(Stk* stack) {
   stack->size = 0;
   stack->mcap = stk_growth_factor;
   stack->data = malloc(stack->mcap * sizeof(u64));
   assert(stack->data);
-}}
+}
 
-void stk_free(Stk* stack) {{
+void stk_free(Stk* stack) {
   free(stack->data);
-}}
+}
 
-void stk_push(Stk* stack, u64 val) {{
-  if (UNLIKELY(stack->size == stack->mcap)) {{ 
+void stk_push(Stk* stack, u64 val) {
+  if (UNLIKELY(stack->size == stack->mcap)) { 
     stack->mcap = stack->mcap * stk_growth_factor;
     stack->data = realloc(stack->data, stack->mcap * sizeof(u64));
-  }}
+  }
   stack->data[stack->size++] = val;
-}}
+}
 
-u64 stk_pop(Stk* stack) {{
-  if (LIKELY(stack->size > 0)) {{
+u64 stk_pop(Stk* stack) {
+  if (LIKELY(stack->size > 0)) {
     // TODO: shrink? -- impacts performance considerably
-    //if (stack->size == stack->mcap / stk_growth_factor) {{
+    //if (stack->size == stack->mcap / stk_growth_factor) {
       //stack->mcap = stack->mcap / stk_growth_factor;
       //stack->data = realloc(stack->data, stack->mcap * sizeof(u64));
       //printf("shrink %llu\n", stack->mcap);
-    //}}
+    //}
     return stack->data[--stack->size];
-  }} else {{
+  } else {
     return -1;
-  }}
-}}
+  }
+}
 
-u64 stk_find(Stk* stk, u64 val) {{
-  for (u64 i = 0; i < stk->size; ++i) {{
-    if (stk->data[i] == val) {{
+u64 stk_find(Stk* stk, u64 val) {
+  for (u64 i = 0; i < stk->size; ++i) {
+    if (stk->data[i] == val) {
       return i;
-    }}
-  }}
+    }
+  }
   return -1;
-}}
+}
 
 // Memory
 // ------
 
-Lnk Var(u64 pos) {{
+Lnk Var(u64 pos) {
   return (VAR * TAG) | pos;
-}}
+}
 
-Lnk Dp0(u64 col, u64 pos) {{
+Lnk Dp0(u64 col, u64 pos) {
   return (DP0 * TAG) | (col * EXT) | pos;
-}}
+}
 
-Lnk Dp1(u64 col, u64 pos) {{
+Lnk Dp1(u64 col, u64 pos) {
   return (DP1 * TAG) | (col * EXT) | pos;
-}}
+}
 
-Lnk Arg(u64 pos) {{
+Lnk Arg(u64 pos) {
   return (ARG * TAG) | pos;
-}}
+}
 
-Lnk Era() {{
+Lnk Era() {
   return (ERA * TAG);
-}}
+}
 
-Lnk Lam(u64 pos) {{
+Lnk Lam(u64 pos) {
   return (LAM * TAG) | pos;
-}}
+}
 
-Lnk App(u64 pos) {{
+Lnk App(u64 pos) {
   return (APP * TAG) | pos;
-}}
+}
 
-Lnk Par(u64 col, u64 pos) {{
+Lnk Par(u64 col, u64 pos) {
   return (PAR * TAG) | (col * EXT) | pos;
-}}
+}
 
-Lnk Op2(u64 ope, u64 pos) {{
+Lnk Op2(u64 ope, u64 pos) {
   return (OP2 * TAG) | (ope * EXT) | pos;
-}}
+}
 
-Lnk U_32(u64 val) {{
+Lnk U_32(u64 val) {
   return (U32 * TAG) | val;
-}}
+}
 
-Lnk Nil() {{
+Lnk Nil() {
   return NIL * TAG;
-}}
+}
 
-Lnk Ctr(u64 ari, u64 fun, u64 pos) {{
+Lnk Ctr(u64 ari, u64 fun, u64 pos) {
   return (CTR * TAG) | (ari * ARI) | (fun * EXT) | pos;
-}}
+}
 
-Lnk Cal(u64 ari, u64 fun, u64 pos) {{ 
+Lnk Cal(u64 ari, u64 fun, u64 pos) { 
   return (CAL * TAG) | (ari * ARI) | (fun * EXT) | pos;
-}}
+}
 
-Lnk Out(u64 arg, u64 fld) {{
+Lnk Out(u64 arg, u64 fld) {
   return (OUT * TAG) | (arg << 8) | fld;
-}}
+}
 
-u64 get_tag(Lnk lnk) {{
+u64 get_tag(Lnk lnk) {
   return lnk / TAG;
-}}
+}
 
-u64 get_ext(Lnk lnk) {{
+u64 get_ext(Lnk lnk) {
   return (lnk / EXT) & 0xFFFFFF;
-}}
+}
 
-u64 get_val(Lnk lnk) {{
+u64 get_val(Lnk lnk) {
   return lnk & 0xFFFFFFFF;
-}}
+}
 
-u64 get_ari(Lnk lnk) {{
+u64 get_ari(Lnk lnk) {
   return (lnk / ARI) & 0xF;
-}}
+}
 
-u64 get_loc(Lnk lnk, u64 arg) {{
+u64 get_loc(Lnk lnk, u64 arg) {
   return get_val(lnk) + arg;
-}}
+}
 
-Lnk ask_lnk(Worker* mem, u64 loc) {{
+Lnk ask_lnk(Worker* mem, u64 loc) {
   return mem->node[loc];
-}}
+}
 
-Lnk ask_arg(Worker* mem, Lnk term, u64 arg) {{
+Lnk ask_arg(Worker* mem, Lnk term, u64 arg) {
   return ask_lnk(mem, get_loc(term, arg));
-}}
+}
 
-u64 link(Worker* mem, u64 loc, Lnk lnk) {{
+u64 link(Worker* mem, u64 loc, Lnk lnk) {
   mem->node[loc] = lnk;
   //array_write(mem->nodes, loc, lnk);
-  if (get_tag(lnk) <= VAR) {{
+  if (get_tag(lnk) <= VAR) {
     mem->node[get_loc(lnk, get_tag(lnk) == DP1 ? 1 : 0)] = Arg(loc);
     //array_write(mem->nodes, get_loc(lnk, get_tag(lnk) == DP1 ? 1 : 0), Arg(loc));
-  }}
+  }
   return lnk;
-}}
+}
 
-u64 alloc(Worker* mem, u64 size) {{
-  if (UNLIKELY(size == 0)) {{
+u64 alloc(Worker* mem, u64 size) {
+  if (UNLIKELY(size == 0)) {
     return 0;
-  }} else {{
+  } else {
     u64 reuse = stk_pop(&mem->free[size]);
-    if (reuse != -1) {{
+    if (reuse != -1) {
       return reuse;
-    }}
+    }
     u64 loc = mem->size;
     mem->size += size;
     return mem->tid * MEM_SPACE + loc;
     //return __atomic_fetch_add(&mem->nodes->size, size, __ATOMIC_RELAXED);
-  }}
-}}
+  }
+}
 
-void clear(Worker* mem, u64 loc, u64 size) {{
+void clear(Worker* mem, u64 loc, u64 size) {
   stk_push(&mem->free[size], loc);
-}}
+}
 
 // Debug
 // -----
 
-void debug_print_lnk(Lnk x) {{
+void debug_print_lnk(Lnk x) {
   u64 tag = get_tag(x);
   u64 ext = get_ext(x);
   u64 val = get_val(x);
-  switch (tag) {{
+  switch (tag) {
     case DP0: printf("DP0"); break;
     case DP1: printf("DP1"); break;
     case VAR: printf("VAR"); break;
@@ -326,179 +326,179 @@ void debug_print_lnk(Lnk x) {{
     case OUT: printf("OUT"); break;
     case NIL: printf("NIL"); break;
     default : printf("???"); break;
-  }}
+  }
   printf(":%llx:%llx", ext, val);
-}}
+}
 
 // Garbage Collection
 // ------------------
 
-void collect(Worker* mem, Lnk term) {{
-  switch (get_tag(term)) {{
-    case DP0: {{
+void collect(Worker* mem, Lnk term) {
+  switch (get_tag(term)) {
+    case DP0: {
       link(mem, get_loc(term,0), Era());
       //reduce(mem, get_loc(ask_arg(mem,term,1),0));
       break;
-    }}
-    case DP1: {{
+    }
+    case DP1: {
       link(mem, get_loc(term,1), Era());
       //reduce(mem, get_loc(ask_arg(mem,term,0),0));
       break;
-    }}
-    case VAR: {{
+    }
+    case VAR: {
       link(mem, get_loc(term,0), Era());
       break;
-    }}
-    case LAM: {{
-      if (get_tag(ask_arg(mem,term,0)) != ERA) {{
+    }
+    case LAM: {
+      if (get_tag(ask_arg(mem,term,0)) != ERA) {
         link(mem, get_loc(ask_arg(mem,term,0),0), Era());
-      }}
+      }
       collect(mem, ask_arg(mem,term,1));
       clear(mem, get_loc(term,0), 2);
       break;
-    }}
-    case APP: {{
+    }
+    case APP: {
       collect(mem, ask_arg(mem,term,0));
       collect(mem, ask_arg(mem,term,1));
       clear(mem, get_loc(term,0), 2);
       break;
-    }}
-    case PAR: {{
+    }
+    case PAR: {
       collect(mem, ask_arg(mem,term,0));
       collect(mem, ask_arg(mem,term,1));
       clear(mem, get_loc(term,0), 2);
       break;
-    }}
-    case OP2: {{
+    }
+    case OP2: {
       collect(mem, ask_arg(mem,term,0));
       collect(mem, ask_arg(mem,term,1));
       break;
-    }}
-    case U32: {{
+    }
+    case U32: {
       break;
-    }}
-    case CTR: case CAL: {{
+    }
+    case CTR: case CAL: {
       u64 arity = get_ari(term);
-      for (u64 i = 0; i < arity; ++i) {{
+      for (u64 i = 0; i < arity; ++i) {
         collect(mem, ask_arg(mem,term,i));
-      }}
+      }
       clear(mem, get_loc(term,0), arity);
       break;
-    }}
-  }}
-}}
+    }
+  }
+}
 
 // Terms
 // -----
 
-void inc_cost(Worker* mem) {{
+void inc_cost(Worker* mem) {
   mem->cost++;
-}}
+}
 
-void subst(Worker* mem, Lnk lnk, Lnk val) {{
-  if (get_tag(lnk) != ERA) {{
+void subst(Worker* mem, Lnk lnk, Lnk val) {
+  if (get_tag(lnk) != ERA) {
     link(mem, get_loc(lnk,0), val);
-  }} else {{
+  } else {
     collect(mem, val);
-  }}
-}}
+  }
+}
 
-Lnk cal_par(Worker* mem, u64 host, Lnk term, Lnk argn, u64 n) {{
+Lnk cal_par(Worker* mem, u64 host, Lnk term, Lnk argn, u64 n) {
   inc_cost(mem);
   u64 arit = get_ari(term);
   u64 func = get_ext(term);
   u64 fun0 = get_loc(term, 0);
   u64 fun1 = alloc(mem, arit);
   u64 par0 = get_loc(argn, 0);
-  for (u64 i = 0; i < arit; ++i) {{
-    if (i != n) {{
+  for (u64 i = 0; i < arit; ++i) {
+    if (i != n) {
       u64 leti = alloc(mem, 3);
       u64 argi = ask_arg(mem, term, i);
       link(mem, fun0+i, Dp0(get_ext(argn), leti));
       link(mem, fun1+i, Dp1(get_ext(argn), leti));
       link(mem, leti+2, argi);
-    }} else {{
+    } else {
       link(mem, fun0+i, ask_arg(mem, argn, 0));
       link(mem, fun1+i, ask_arg(mem, argn, 1));
-    }}
-  }}
+    }
+  }
   link(mem, par0+0, Cal(arit, func, fun0));
   link(mem, par0+1, Cal(arit, func, fun1));
   u64 done = Par(get_ext(argn), par0);
   link(mem, host, done);
   return done;
-}}
+}
 
-Lnk reduce(Worker* mem, u64 root, u64 slen) {{
+Lnk reduce(Worker* mem, u64 root, u64 slen) {
   Stk stack;
   stk_init(&stack);
 
   u64 init = 1;
   u32 host = (u32)root;
 
-  while (1) {{
+  while (1) {
 
     u64 term = ask_lnk(mem, host);
 
     //printf("reducing: host=%d size=%llu init=%llu ", host, stack.size, init); debug_print_lnk(term); printf("\n");
-    //for (u64 i = 0; i < size; ++i) {{
+    //for (u64 i = 0; i < size; ++i) {
       //printf("- %llu ", stack[i]); debug_print_lnk(ask_lnk(mem, stack[i]>>1)); printf("\n");
-    //}}
+    //}
     
-    if (init == 1) {{
-      switch (get_tag(term)) {{
-        case APP: {{
+    if (init == 1) {
+      switch (get_tag(term)) {
+        case APP: {
           stk_push(&stack, host);
           //stack[size++] = host;
           init = 1;
           host = get_loc(term, 0);
           continue;
-        }}
+        }
         case DP0:
-        case DP1: {{
+        case DP1: {
           // TODO: reason about this, comment
           atomic_flag* flag = ((atomic_flag*)(mem->node + get_loc(term,0))) + 6;
-          if (atomic_flag_test_and_set(flag) != 0) {{
+          if (atomic_flag_test_and_set(flag) != 0) {
             continue;
-          }}
+          }
           stk_push(&stack, host);
           host = get_loc(term, 2);
           continue;
-        }}
-        case OP2: {{
+        }
+        case OP2: {
           //printf("op2 %llu %llu\n", slen, stack.size);
-          if (slen == 1 || stack.size > 0) {{
+          if (slen == 1 || stack.size > 0) {
             stk_push(&stack, host);
             stk_push(&stack, get_loc(term, 0) | 0x80000000);
             //stack[size++] = host;
             //stack[size++] = get_loc(term, 0) | 0x80000000;
             host = get_loc(term, 1);
             continue;
-          }}
+          }
           break;
-        }}
-        case CAL: {{
+        }
+        case CAL: {
           u64 fun = get_ext(term);
           u64 ari = get_ari(term);
           
           switch (fun)
           //GENERATED_REWRITE_RULES_STEP_0_START//
-          {{
-{inits}
-          }}
+          {
+/* GENERATED_REWRITE_RULES_STEP_0_CONTENT */
+          }
           //GENERATED_REWRITE_RULES_STEP_0_END//
 
           break;
-        }}
-      }}
+        }
+      }
 
-    }} else {{
+    } else {
 
-      switch (get_tag(term)) {{
-        case APP: {{
+      switch (get_tag(term)) {
+        case APP: {
           u64 arg0 = ask_arg(mem, term, 0);
-          switch (get_tag(arg0)) {{
-            case LAM: {{
+          switch (get_tag(arg0)) {
+            case LAM: {
               inc_cost(mem);
               subst(mem, ask_arg(mem, arg0, 0), ask_arg(mem, term, 1));
               u64 done = link(mem, host, ask_arg(mem, arg0, 1));
@@ -506,8 +506,8 @@ Lnk reduce(Worker* mem, u64 root, u64 slen) {{
               clear(mem, get_loc(arg0,0), 2);
               init = 1;
               continue;
-            }}
-            case PAR: {{
+            }
+            case PAR: {
               inc_cost(mem);
               u64 app0 = get_loc(term, 0);
               u64 app1 = get_loc(arg0, 0);
@@ -523,15 +523,15 @@ Lnk reduce(Worker* mem, u64 root, u64 slen) {{
               u64 done = Par(get_ext(arg0), par0);
               link(mem, host, done);
               break;
-            }}
-          }}
+            }
+          }
           break;
-        }}
+        }
         case DP0:
-        case DP1: {{
+        case DP1: {
           u64 arg0 = ask_arg(mem, term, 2);
-          switch (get_tag(arg0)) {{
-            case LAM: {{
+          switch (get_tag(arg0)) {
+            case LAM: {
               inc_cost(mem);
               u64 let0 = get_loc(term, 0);
               u64 par0 = get_loc(arg0, 0);
@@ -552,9 +552,9 @@ Lnk reduce(Worker* mem, u64 root, u64 slen) {{
               link(mem, host, done);
               init = 1;
               continue;
-            }}
-            case PAR: {{
-              if (get_ext(term) == get_ext(arg0)) {{
+            }
+            case PAR: {
+              if (get_ext(term) == get_ext(arg0)) {
                 inc_cost(mem);
                 subst(mem, ask_arg(mem,term,0), ask_arg(mem,arg0,0));
                 subst(mem, ask_arg(mem,term,1), ask_arg(mem,arg0,1));
@@ -563,7 +563,7 @@ Lnk reduce(Worker* mem, u64 root, u64 slen) {{
                 clear(mem, get_loc(arg0,0), 2);
                 init = 1;
                 continue;
-              }} else {{
+              } else {
                 inc_cost(mem);
                 u64 par0 = alloc(mem, 2);
                 u64 let0 = get_loc(term,0);
@@ -582,59 +582,59 @@ Lnk reduce(Worker* mem, u64 root, u64 slen) {{
                 u64 done = Par(get_ext(arg0), get_tag(term) == DP0 ? par0 : par1);
                 link(mem, host, done);
                 break;
-              }}
-            }}
-          }}
-          if (get_tag(arg0) == U32) {{
+              }
+            }
+          }
+          if (get_tag(arg0) == U32) {
             inc_cost(mem);
             subst(mem, ask_arg(mem,term,0), arg0);
             subst(mem, ask_arg(mem,term,1), arg0);
             u64 done = arg0;
             link(mem, host, arg0);
             break;
-          }}
-          if (get_tag(arg0) == CTR) {{
+          }
+          if (get_tag(arg0) == CTR) {
             inc_cost(mem);
             u64 func = get_ext(arg0);
             u64 arit = get_ari(arg0);
-            if (arit == 0) {{
+            if (arit == 0) {
               subst(mem, ask_arg(mem,term,0), Ctr(0, func, 0));
               subst(mem, ask_arg(mem,term,1), Ctr(0, func, 0));
               clear(mem, get_loc(term,0), 3);
               u64 done = link(mem, host, Ctr(0, func, 0));
-            }} else {{
+            } else {
               u64 ctr0 = get_loc(arg0,0);
               u64 ctr1 = alloc(mem, arit);
               u64 term_arg_0 = ask_arg(mem,term,0);
               u64 term_arg_1 = ask_arg(mem,term,1);
-              for (u64 i = 0; i < arit; ++i) {{
+              for (u64 i = 0; i < arit; ++i) {
                 u64 leti = i == 0 ? get_loc(term,0) : alloc(mem, 3);
                 u64 arg0_arg_i = ask_arg(mem, arg0, i);
                 link(mem, ctr0+i, Dp0(get_ext(term), leti));
                 link(mem, ctr1+i, Dp1(get_ext(term), leti));
                 link(mem, leti+2, arg0_arg_i);
-              }}
+              }
               subst(mem, term_arg_0, Ctr(arit, func, ctr0));
               subst(mem, term_arg_1, Ctr(arit, func, ctr1));
               u64 done = Ctr(arit, func, get_tag(term) == DP0 ? ctr0 : ctr1);
               link(mem, host, done);
-            }}
+            }
             break;
-          }}
+          }
           atomic_flag* flag = ((atomic_flag*)(mem->node + get_loc(term,0))) + 6;
           atomic_flag_clear(flag);
           break;
-        }}
-        case OP2: {{
+        }
+        case OP2: {
           //printf("! op2 %llu %llu\n", slen, stack.size);
           u64 arg0 = ask_arg(mem, term, 0);
           u64 arg1 = ask_arg(mem, term, 1);
-          if (get_tag(arg0) == U32 && get_tag(arg1) == U32) {{
+          if (get_tag(arg0) == U32 && get_tag(arg1) == U32) {
             inc_cost(mem);
             u64 a = get_val(arg0);
             u64 b = get_val(arg1);
             u64 c = 0;
-            switch (get_ext(term)) {{
+            switch (get_ext(term)) {
               case ADD: c = (a +  b) & 0xFFFFFFFF; break;
               case SUB: c = (a -  b) & 0xFFFFFFFF; break;
               case MUL: c = (a *  b) & 0xFFFFFFFF; break;
@@ -651,13 +651,13 @@ Lnk reduce(Worker* mem, u64 root, u64 slen) {{
               case GTE: c = (a >= b) ? 1 : 0;      break;
               case GTN: c = (a >  b) ? 1 : 0;      break;
               case NEQ: c = (a != b) ? 1 : 0;      break;
-            }}
+            }
             u64 done = U_32(c);
             clear(mem, get_loc(term,0), 2);
             link(mem, host, done);
             break;
-          }}
-          if (get_tag(arg0) == PAR) {{
+          }
+          if (get_tag(arg0) == PAR) {
             inc_cost(mem);
             u64 op20 = get_loc(term, 0);
             u64 op21 = get_loc(arg0, 0);
@@ -673,8 +673,8 @@ Lnk reduce(Worker* mem, u64 root, u64 slen) {{
             u64 done = Par(get_ext(arg0), par0);
             link(mem, host, done);
             break;
-          }}
-          if (get_tag(arg1) == PAR) {{
+          }
+          if (get_tag(arg1) == PAR) {
             inc_cost(mem);
             u64 op20 = get_loc(term, 0);
             u64 op21 = get_loc(arg1, 0);
@@ -690,48 +690,48 @@ Lnk reduce(Worker* mem, u64 root, u64 slen) {{
             u64 done = Par(get_ext(arg1), par0);
             link(mem, host, done);
             break;
-          }}
+          }
           break;
-        }}
-        case CAL: {{
+        }
+        case CAL: {
           u64 fun = get_ext(term);
           u64 ari = get_ari(term);
 
           switch (fun)
           //GENERATED_REWRITE_RULES_STEP_1_START//
-          {{
-{codes}
-          }}
+          {
+/* GENERATED_REWRITE_RULES_STEP_1_CONTENT */
+          }
           //GENERATED_REWRITE_RULES_STEP_1_END//
 
           break;
-        }}
-      }}
-    }}
+        }
+      }
+    }
 
     u64 item = stk_pop(&stack);
-    if (item == -1) {{
+    if (item == -1) {
       break;
-    }} else {{
+    } else {
       init = item >> 31;
       host = item & 0x7FFFFFFF;
       continue;
-    }}
+    }
 
-  }}
+  }
 
   return ask_lnk(mem, root);
-}}
+}
 
 // sets the nth bit of a bit-array represented as a u64 array
-void set_bit(u64* bits, u64 bit) {{
+void set_bit(u64* bits, u64 bit) {
   bits[bit >> 6] |= (1ULL << (bit & 0x3f));
-}}
+}
 
 // gets the nth bit of a bit-array represented as a u64 array
-u8 get_bit(u64* bits, u64 bit) {{
+u8 get_bit(u64* bits, u64 bit) {
   return (bits[bit >> 6] >> (bit & 0x3F)) & 1;
-}}
+}
 
 #ifdef PARALLEL
 void normal_fork(u64 tid, u64 host, u64 sidx, u64 slen);
@@ -740,99 +740,99 @@ u64  normal_join(u64 tid);
 
 u64 normal_seen_data[NORMAL_SEEN_MCAP];
 
-void normal_init() {{
-  for (u64 i = 0; i < NORMAL_SEEN_MCAP; ++i) {{
+void normal_init() {
+  for (u64 i = 0; i < NORMAL_SEEN_MCAP; ++i) {
     normal_seen_data[i] = 0;
-  }}
-}}
+  }
+}
 
-Lnk normal_go(Worker* mem, u64 host, u64 sidx, u64 slen) {{
+Lnk normal_go(Worker* mem, u64 host, u64 sidx, u64 slen) {
   Lnk term = ask_lnk(mem, host);
   //printf("normal %llu %llu | ", sidx, slen); debug_print_lnk(term); printf("\n");
-  if (get_bit(normal_seen_data, host)) {{
+  if (get_bit(normal_seen_data, host)) {
     return term;
-  }} else {{
+  } else {
     term = reduce(mem, host, slen);
     set_bit(normal_seen_data, host);
     u64 rec_size = 0;
     u64 rec_locs[16];
-    switch (get_tag(term)) {{
-      case LAM: {{
+    switch (get_tag(term)) {
+      case LAM: {
         rec_locs[rec_size++] = get_loc(term,1);
         break;
-      }}
-      case APP: {{
+      }
+      case APP: {
         rec_locs[rec_size++] = get_loc(term,0);
         rec_locs[rec_size++] = get_loc(term,1);
         break;
-      }}
-      case PAR: {{
+      }
+      case PAR: {
         rec_locs[rec_size++] = get_loc(term,0);
         rec_locs[rec_size++] = get_loc(term,1);
         break;
-      }}
-      case DP0: {{
+      }
+      case DP0: {
         rec_locs[rec_size++] = get_loc(term,2);
         break;
-      }}
-      case DP1: {{
+      }
+      case DP1: {
         rec_locs[rec_size++] = get_loc(term,2);
         break;
-      }}
-      case OP2: {{
-        if (slen > 1) {{
+      }
+      case OP2: {
+        if (slen > 1) {
           rec_locs[rec_size++] = get_loc(term,0);
           rec_locs[rec_size++] = get_loc(term,1);
           break;
-        }}
-      }}
-      case CTR: case CAL: {{
+        }
+      }
+      case CTR: case CAL: {
         u64 arity = (u64)get_ari(term);
-        for (u64 i = 0; i < arity; ++i) {{
+        for (u64 i = 0; i < arity; ++i) {
           rec_locs[rec_size++] = get_loc(term,i);
-        }}
+        }
         break;
-      }}
-    }}
+      }
+    }
     #ifdef PARALLEL
 
     //printf("ue %llu %llu\n", rec_size, slen);
     
-    if (rec_size >= 2 && slen >= rec_size) {{
+    if (rec_size >= 2 && slen >= rec_size) {
 
       u64 space = slen / rec_size;
 
-      for (u64 i = 1; i < rec_size; ++i) {{
+      for (u64 i = 1; i < rec_size; ++i) {
         //printf("spawn %llu %llu\n", sidx + i * space, space);
         normal_fork(sidx + i * space, rec_locs[i], sidx + i * space, space);
-      }}
+      }
 
       link(mem, rec_locs[0], normal_go(mem, rec_locs[0], sidx, space));
 
-      for (u64 i = 1; i < rec_size; ++i) {{
+      for (u64 i = 1; i < rec_size; ++i) {
         link(mem, get_loc(term, i), normal_join(sidx + i * space));
-      }}
+      }
 
-    }} else {{
+    } else {
 
-      for (u64 i = 0; i < rec_size; ++i) {{
+      for (u64 i = 0; i < rec_size; ++i) {
         link(mem, rec_locs[i], normal_go(mem, rec_locs[i], sidx, slen));
-      }}
+      }
 
-    }}
+    }
     #else
 
-    for (u64 i = 0; i < rec_size; ++i) {{
+    for (u64 i = 0; i < rec_size; ++i) {
       link(mem, rec_locs[i], normal_go(mem, rec_locs[i], sidx, slen));
-    }}
+    }
 
     #endif
 
     return term;
-  }}
-}}
+  }
+}
 
-Lnk normal(Worker* mem, u64 host, u64 sidx, u64 slen) {{
+Lnk normal(Worker* mem, u64 host, u64 sidx, u64 slen) {
   // In order to allow parallelization of numeric operations, reduce() will treat OP2 as a CTR if
   // there is enough thread space. So, for example, normalizing a recursive "sum" function with 4
   // threads might return something like `(+ (+ 64 64) (+ 64 64))`. reduce() will treat the first
@@ -842,53 +842,53 @@ Lnk normal(Worker* mem, u64 host, u64 sidx, u64 slen) {{
   normal_go(mem, host, sidx, slen);
   normal_init();
   return normal_go(mem, host, 0, 1);
-}}
+}
 
 
 #ifdef PARALLEL
 
 // Normalizes in a separate thread
-void normal_fork(u64 tid, u64 host, u64 sidx, u64 slen) {{
+void normal_fork(u64 tid, u64 host, u64 sidx, u64 slen) {
   pthread_mutex_lock(&workers[tid].has_work_mutex);
   workers[tid].has_work = (sidx << 48) | (slen << 32) | host;
   pthread_cond_signal(&workers[tid].has_work_signal);
   pthread_mutex_unlock(&workers[tid].has_work_mutex);
-}}
+}
 
 // Waits the result of a forked normalizer
-u64 normal_join(u64 tid) {{
-  while (1) {{
+u64 normal_join(u64 tid) {
+  while (1) {
     pthread_mutex_lock(&workers[tid].has_result_mutex);
-    while (workers[tid].has_result == -1) {{
+    while (workers[tid].has_result == -1) {
       pthread_cond_wait(&workers[tid].has_result_signal, &workers[tid].has_result_mutex);
-    }}
+    }
     u64 done = workers[tid].has_result;
     workers[tid].has_result = -1;
     pthread_mutex_unlock(&workers[tid].has_result_mutex);
     return done;
-  }}
-}}
+  }
+}
 
 // Stops a worker
-void worker_stop(u64 tid) {{
+void worker_stop(u64 tid) {
   pthread_mutex_lock(&workers[tid].has_work_mutex);
   workers[tid].has_work = -2;
   pthread_cond_signal(&workers[tid].has_work_signal);
   pthread_mutex_unlock(&workers[tid].has_work_mutex);
-}}
+}
 
 // The normalizer worker
-void *worker(void *arg) {{
+void *worker(void *arg) {
   u64 tid = (u64)arg;
-  while (1) {{
+  while (1) {
     pthread_mutex_lock(&workers[tid].has_work_mutex);
-    while (workers[tid].has_work == -1) {{
+    while (workers[tid].has_work == -1) {
       pthread_cond_wait(&workers[tid].has_work_signal, &workers[tid].has_work_mutex);
-    }}
+    }
     u64 work = workers[tid].has_work;
-    if (work == -2) {{
+    if (work == -2) {
       break;
-    }} else {{
+    } else {
       u64 sidx = (work >> 48) & 0xFFFF;
       u64 slen = (work >> 32) & 0xFFFF;
       u64 host = (work >>  0) & 0xFFFFFFFF;
@@ -896,26 +896,26 @@ void *worker(void *arg) {{
       workers[tid].has_work = -1;
       pthread_cond_signal(&workers[tid].has_result_signal);
       pthread_mutex_unlock(&workers[tid].has_work_mutex);
-    }}
-  }}
+    }
+  }
   return 0;
-}}
+}
 
 #endif
 
 u64 ffi_cost;
 u64 ffi_size;
 
-void ffi_normal(u8* mem_data, u32 mem_size, u32 host) {{
+void ffi_normal(u8* mem_data, u32 mem_size, u32 host) {
 
   // Init thread objects
-  for (u64 t = 0; t < MAX_WORKERS; ++t) {{
+  for (u64 t = 0; t < MAX_WORKERS; ++t) {
     workers[t].tid = t;
     workers[t].size = t == 0 ? (u64)mem_size : 0l;
     workers[t].node = (u64*)mem_data;
-    for (u64 a = 0; a < MAX_ARITY; ++a) {{
+    for (u64 a = 0; a < MAX_ARITY; ++a) {
       stk_init(&workers[t].free[a]);
-    }}
+    }
     workers[t].cost = 0;
     #ifdef PARALLEL
     workers[t].has_work = -1;
@@ -926,13 +926,13 @@ void ffi_normal(u8* mem_data, u32 mem_size, u32 host) {{
     pthread_cond_init(&workers[t].has_result_signal, NULL);
     // workers[t].thread = NULL;
     #endif
-  }}
+  }
 
   // Spawns threads
   #ifdef PARALLEL
-  for (u64 tid = 1; tid < MAX_WORKERS; ++tid) {{
+  for (u64 tid = 1; tid < MAX_WORKERS; ++tid) {
     pthread_create(&workers[tid].thread, NULL, &worker, (void*)tid);
-  }}
+  }
   #endif
 
   // Normalizes trm
@@ -941,226 +941,226 @@ void ffi_normal(u8* mem_data, u32 mem_size, u32 host) {{
   // Computes total cost and size
   ffi_cost = 0;
   ffi_size = 0;
-  for (u64 tid = 0; tid < MAX_WORKERS; ++tid) {{
+  for (u64 tid = 0; tid < MAX_WORKERS; ++tid) {
     ffi_cost += workers[tid].cost;
     ffi_size += workers[tid].size;
-  }}
+  }
 
   // Asks workers to stop
-  for (u64 tid = 1; tid < MAX_WORKERS; ++tid) {{
+  for (u64 tid = 1; tid < MAX_WORKERS; ++tid) {
     worker_stop(tid);
-  }}
+  }
 
   // Waits workers to stop
-  for (u64 tid = 1; tid < MAX_WORKERS; ++tid) {{
+  for (u64 tid = 1; tid < MAX_WORKERS; ++tid) {
     pthread_join(workers[tid].thread, NULL);
-  }}
+  }
 
   // Clears workers
-  for (u64 tid = 0; tid < MAX_WORKERS; ++tid) {{
-    for (u64 a = 0; a < MAX_ARITY; ++a) {{
+  for (u64 tid = 0; tid < MAX_WORKERS; ++tid) {
+    for (u64 a = 0; a < MAX_ARITY; ++a) {
       stk_free(&workers[tid].free[a]);
-    }}
+    }
     #ifdef PARALLEL
     pthread_mutex_destroy(&workers[tid].has_work_mutex);
     pthread_cond_destroy(&workers[tid].has_work_signal);
     pthread_mutex_destroy(&workers[tid].has_result_mutex);
     pthread_cond_destroy(&workers[tid].has_result_signal);
     #endif
-  }}
-}}
+  }
+}
 
 // Readback
 // --------
 
-void readback_vars(Stk* vars, Worker* mem, Lnk term, Stk* seen) {{
+void readback_vars(Stk* vars, Worker* mem, Lnk term, Stk* seen) {
   //printf("- readback_vars %llu ", get_loc(term,0)); debug_print_lnk(term); printf("\n");
-  if (stk_find(seen, term) != -1) {{ // FIXME: probably very slow, change to a proper hashmap
+  if (stk_find(seen, term) != -1) { // FIXME: probably very slow, change to a proper hashmap
     return;
-  }} else {{
+  } else {
     stk_push(seen, term);
-    switch (get_tag(term)) {{
-      case LAM: {{
+    switch (get_tag(term)) {
+      case LAM: {
         u64 argm = ask_arg(mem, term, 0);
         u64 body = ask_arg(mem, term, 1);
-        if (get_tag(argm) != ERA) {{
+        if (get_tag(argm) != ERA) {
           stk_push(vars, Var(get_loc(term, 0)));
-        }};
+        };
         readback_vars(vars, mem, body, seen);
         break;
-      }}
-      case APP: {{
+      }
+      case APP: {
         u64 lam = ask_arg(mem, term, 0);
         u64 arg = ask_arg(mem, term, 1);
         readback_vars(vars, mem, lam, seen);
         readback_vars(vars, mem, arg, seen);
         break;
-      }}
-      case PAR: {{
+      }
+      case PAR: {
         u64 arg0 = ask_arg(mem, term, 0);
         u64 arg1 = ask_arg(mem, term, 1);
         readback_vars(vars, mem, arg0, seen);
         readback_vars(vars, mem, arg1, seen);
         break;
-      }}
-      case DP0: {{
+      }
+      case DP0: {
         u64 arg = ask_arg(mem, term, 2);
         readback_vars(vars, mem, arg, seen);
         break;
-      }}
-      case DP1: {{
+      }
+      case DP1: {
         u64 arg = ask_arg(mem, term, 2);
         readback_vars(vars, mem, arg, seen);
         break;
-      }}
-      case OP2: {{
+      }
+      case OP2: {
         u64 arg0 = ask_arg(mem, term, 0);
         u64 arg1 = ask_arg(mem, term, 1);
         readback_vars(vars, mem, arg0, seen);
         readback_vars(vars, mem, arg1, seen);
         break;
-      }}
-      case CTR: case CAL: {{
+      }
+      case CTR: case CAL: {
         u64 arity = get_ari(term);
-        for (u64 i = 0; i < arity; ++i) {{
+        for (u64 i = 0; i < arity; ++i) {
           readback_vars(vars, mem, ask_arg(mem, term, i), seen);
-        }}
+        }
         break;
-      }}
-    }}
-  }}
-}}
+      }
+    }
+  }
+}
 
-void readback_decimal_go(Stk* chrs, u64 n) {{
+void readback_decimal_go(Stk* chrs, u64 n) {
   //printf("--- A %llu\n", n);
-  if (n > 0) {{
+  if (n > 0) {
     readback_decimal_go(chrs, n / 10);
     stk_push(chrs, '0' + (n % 10));
-  }}
-}}
+  }
+}
 
-void readback_decimal(Stk* chrs, u64 n) {{
-  if (n == 0) {{
+void readback_decimal(Stk* chrs, u64 n) {
+  if (n == 0) {
     stk_push(chrs, '0');
-  }} else {{
+  } else {
     readback_decimal_go(chrs, n);
-  }}
-}}
+  }
+}
 
-void readback_term(Stk* chrs, Worker* mem, Lnk term, Stk* vars, Stk* dirs, char** id_to_name_data, u64 id_to_name_mcap) {{
+void readback_term(Stk* chrs, Worker* mem, Lnk term, Stk* vars, Stk* dirs, char** id_to_name_data, u64 id_to_name_mcap) {
   //printf("- readback_term: "); debug_print_lnk(term); printf("\n");
-  switch (get_tag(term)) {{
-    case LAM: {{
+  switch (get_tag(term)) {
+    case LAM: {
       stk_push(chrs, '%');
-      if (get_tag(ask_arg(mem, term, 0)) == ERA) {{
+      if (get_tag(ask_arg(mem, term, 0)) == ERA) {
         stk_push(chrs, '~');
-      }} else {{
+      } else {
         stk_push(chrs, 'x');
         readback_decimal(chrs, stk_find(vars, Var(get_loc(term, 0))));
-      }};
+      };
       stk_push(chrs, ' ');
       readback_term(chrs, mem, ask_arg(mem, term, 1), vars, dirs, id_to_name_data, id_to_name_mcap);
       break;
-    }}
-    case APP: {{
+    }
+    case APP: {
       stk_push(chrs, '(');
       readback_term(chrs, mem, ask_arg(mem, term, 0), vars, dirs, id_to_name_data, id_to_name_mcap);
       stk_push(chrs, ' ');
       readback_term(chrs, mem, ask_arg(mem, term, 1), vars, dirs, id_to_name_data, id_to_name_mcap);
       stk_push(chrs, ')');
       break;
-    }}
-    case PAR: {{
+    }
+    case PAR: {
       u64 col = get_ext(term);
-      if (dirs[col].size > 0) {{
+      if (dirs[col].size > 0) {
         u64 head = stk_pop(&dirs[col]);
-        if (head == 0) {{
+        if (head == 0) {
           readback_term(chrs, mem, ask_arg(mem, term, 0), vars, dirs, id_to_name_data, id_to_name_mcap);
           stk_push(&dirs[col], head);
-        }} else {{
+        } else {
           readback_term(chrs, mem, ask_arg(mem, term, 1), vars, dirs, id_to_name_data, id_to_name_mcap);
           stk_push(&dirs[col], head);
-        }}
-      }} else {{
+        }
+      } else {
         stk_push(chrs, '<');
         readback_term(chrs, mem, ask_arg(mem, term, 0), vars, dirs, id_to_name_data, id_to_name_mcap);
         stk_push(chrs, ' ');
         readback_term(chrs, mem, ask_arg(mem, term, 1), vars, dirs, id_to_name_data, id_to_name_mcap);
         stk_push(chrs, '>');
-      }}
+      }
       break;
-    }}
-    case DP0: case DP1: {{
+    }
+    case DP0: case DP1: {
       u64 col = get_ext(term);
       u64 val = ask_arg(mem, term, 2);
       stk_push(&dirs[col], get_tag(term) == DP0 ? 0 : 1);
       readback_term(chrs, mem, ask_arg(mem, term, 2), vars, dirs, id_to_name_data, id_to_name_mcap);
       stk_pop(&dirs[col]);
       break;
-    }}
-    case OP2: {{
+    }
+    case OP2: {
       stk_push(chrs, '(');
       readback_term(chrs, mem, ask_arg(mem, term, 0), vars, dirs, id_to_name_data, id_to_name_mcap);
-      switch (get_ext(term)) {{
-        case ADD: {{ stk_push(chrs, '+'); break; }}
-        case SUB: {{ stk_push(chrs, '-'); break; }}
-        case MUL: {{ stk_push(chrs, '*'); break; }}
-        case DIV: {{ stk_push(chrs, '/'); break; }}
-        case MOD: {{ stk_push(chrs, '%'); break; }}
-        case AND: {{ stk_push(chrs, '&'); break; }}
-        case OR: {{ stk_push(chrs, '|'); break; }}
-        case XOR: {{ stk_push(chrs, '^'); break; }}
-        case SHL: {{ stk_push(chrs, '<'); stk_push(chrs, '<'); break; }}
-        case SHR: {{ stk_push(chrs, '>'); stk_push(chrs, '>'); break; }}
-        case LTN: {{ stk_push(chrs, '<'); break; }}
-        case LTE: {{ stk_push(chrs, '<'); stk_push(chrs, '='); break; }}
-        case EQL: {{ stk_push(chrs, '='); stk_push(chrs, '='); break; }}
-        case GTE: {{ stk_push(chrs, '>'); stk_push(chrs, '='); break; }}
-        case GTN: {{ stk_push(chrs, '>'); break; }}
-        case NEQ: {{ stk_push(chrs, '!'); stk_push(chrs, '='); break; }}
-      }}
+      switch (get_ext(term)) {
+        case ADD: { stk_push(chrs, '+'); break; }
+        case SUB: { stk_push(chrs, '-'); break; }
+        case MUL: { stk_push(chrs, '*'); break; }
+        case DIV: { stk_push(chrs, '/'); break; }
+        case MOD: { stk_push(chrs, '%'); break; }
+        case AND: { stk_push(chrs, '&'); break; }
+        case OR: { stk_push(chrs, '|'); break; }
+        case XOR: { stk_push(chrs, '^'); break; }
+        case SHL: { stk_push(chrs, '<'); stk_push(chrs, '<'); break; }
+        case SHR: { stk_push(chrs, '>'); stk_push(chrs, '>'); break; }
+        case LTN: { stk_push(chrs, '<'); break; }
+        case LTE: { stk_push(chrs, '<'); stk_push(chrs, '='); break; }
+        case EQL: { stk_push(chrs, '='); stk_push(chrs, '='); break; }
+        case GTE: { stk_push(chrs, '>'); stk_push(chrs, '='); break; }
+        case GTN: { stk_push(chrs, '>'); break; }
+        case NEQ: { stk_push(chrs, '!'); stk_push(chrs, '='); break; }
+      }
       readback_term(chrs, mem, ask_arg(mem, term, 1), vars, dirs, id_to_name_data, id_to_name_mcap);
       stk_push(chrs, ')');
       break;
-    }}
-    case U32: {{
+    }
+    case U32: {
       //printf("- u32\n");
       readback_decimal(chrs, get_val(term));
       //printf("- u32 done\n");
       break;
-    }}
-    case CTR: case CAL: {{
+    }
+    case CTR: case CAL: {
       u64 func = get_ext(term);
       u64 arit = get_ari(term);
       stk_push(chrs, '(');
-      if (func < id_to_name_mcap && id_to_name_data[func] != NULL) {{
-        for (u64 i = 0; id_to_name_data[func][i] != '\0'; ++i) {{
+      if (func < id_to_name_mcap && id_to_name_data[func] != NULL) {
+        for (u64 i = 0; id_to_name_data[func][i] != '\0'; ++i) {
           stk_push(chrs, id_to_name_data[func][i]);
-        }}
-      }} else {{
+        }
+      } else {
         stk_push(chrs, '$');
         readback_decimal(chrs, func); // TODO: function names
-      }}
-      for (u64 i = 0; i < arit; ++i) {{
+      }
+      for (u64 i = 0; i < arit; ++i) {
         stk_push(chrs, ' ');
         readback_term(chrs, mem, ask_arg(mem, term, i), vars, dirs, id_to_name_data, id_to_name_mcap);
-      }}
+      }
       stk_push(chrs, ')');
       break;
-    }}
-    case VAR: {{
+    }
+    case VAR: {
       stk_push(chrs, 'x');
       readback_decimal(chrs, stk_find(vars, term));
       break;
-    }}
-    default: {{
+    }
+    default: {
       stk_push(chrs, '?');
       break;
-    }}
-  }}
-}}
+    }
+  }
+}
 
-void readback(char* code_data, u64 code_mcap, Worker* mem, Lnk term, char** id_to_name_data, u64 id_to_name_mcap) {{
+void readback(char* code_data, u64 code_mcap, Worker* mem, Lnk term, char** id_to_name_data, u64 id_to_name_mcap) {
   //printf("reading back\n");
 
   // Constants
@@ -1178,63 +1178,63 @@ void readback(char* code_data, u64 code_mcap, Worker* mem, Lnk term, char** id_t
   stk_init(&vars);
   dirs = (Stk*)malloc(sizeof(Stk) * dirs_mcap);
   assert(dirs);
-  for (u64 i = 0; i < dirs_mcap; ++i) {{
+  for (u64 i = 0; i < dirs_mcap; ++i) {
     stk_init(&dirs[i]);
-  }}
+  }
 
   // Readback
   readback_vars(&vars, mem, term, &seen);
   readback_term(&chrs, mem, term, &vars, dirs, id_to_name_data, id_to_name_mcap);
 
   // Generates C string
-  for (u64 i = 0; i < chrs.size && i < code_mcap; ++i) {{
+  for (u64 i = 0; i < chrs.size && i < code_mcap; ++i) {
     code_data[i] = chrs.data[i];
-  }}
+  }
   code_data[chrs.size < code_mcap ? chrs.size : code_mcap] = '\0';
 
   // Cleanup
   stk_free(&seen);
   stk_free(&chrs);
   stk_free(&vars);
-  for (u64 i = 0; i < dirs_mcap; ++i) {{
+  for (u64 i = 0; i < dirs_mcap; ++i) {
     stk_free(&dirs[i]);
-  }}
-}}
+  }
+}
 
 // Main
 // ----
 
-Lnk parse_arg(char* code, char** id_to_name_data, u64 id_to_name_size) {{
-  if (code[0] >= '0' && code[0] <= '9') {{
+Lnk parse_arg(char* code, char** id_to_name_data, u64 id_to_name_size) {
+  if (code[0] >= '0' && code[0] <= '9') {
     return U_32(strtol(code, 0, 10));
-  }} else {{
+  } else {
     return U_32(0);
-  }}
-}}
+  }
+}
 
 // Uncomment to test without Deno FFI
-int main(int argc, char* argv[]) {{
+int main(int argc, char* argv[]) {
 
   Worker mem;
   struct timeval stop, start;
 
   // Id-to-Name map
-  const u64 id_to_name_size = {names_count};
+  const u64 id_to_name_size = /* GENERATED_NAME_COUNT_CONTENT */;
   char* id_to_name_data[id_to_name_size];
-{id2nm}
+/* GENERATED_ID_TO_NAME_DATA_CONTENT */;
 
   // Builds main term
   mem.size = 0;
   mem.node = (u64*)malloc(HEAP_SIZE);
   assert(mem.node);
-  if (argc <= 1) {{
+  if (argc <= 1) {
     mem.node[mem.size++] = Cal(0, _MAIN_, 0);
-  }} else {{
+  } else {
     mem.node[mem.size++] = Cal(argc - 1, _MAIN_, 1);
-    for (u64 i = 1; i < argc; ++i) {{
+    for (u64 i = 1; i < argc; ++i) {
       mem.node[mem.size++] = parse_arg(argv[i], id_to_name_data, id_to_name_size);
-    }}
-  }}
+    }
+  }
 
   // Reduces and benchmarks
   //printf("Reducing.\n");
@@ -1259,4 +1259,4 @@ int main(int argc, char* argv[]) {{
   // Cleanup
   free(code_data);
   free(mem.node);
-}}
+}


### PR DESCRIPTION
This allows the use of regular `{` and `}` tokens in the C file instead of the escaping required for every scope and control flow structure. It should be a QOL improvement while developing the C file, compared to the cost of a few string allocations while compiling to C ?

Also a couple of drive-by changes: 
- removes some, I believe unused, cranelift crates: hvm will be faster to build
- some automated rustfmt, and println simplifications

(I haven't fully tested this, only on one example, which seemed to work. Hopefully CI will soon be able to test this PR)