### PR TITLE
Improve and add tests for parser.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,77 @@
 version = 3
 
 [[package]]
+name = "autocfg"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdb031dd78e28731d87d56cc8ffef4a8f36ca26c38fe2de700543e627f8a464a"
+
+[[package]]
+name = "bit-set"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e11e16035ea35e4e5997b393eacbf6f63983188f7a2ad25bfb13465f5ad59de"
+dependencies = [
+ "bit-vec",
+]
+
+[[package]]
+name = "bit-vec"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "349f9b6a179ed607305526ca489b34ad0a41aed5f7980fa90eb03160b69598fb"
+
+[[package]]
+name = "bitflags"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
+
+[[package]]
+name = "byteorder"
+version = "1.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "14c189c53d098945499cdfa7ecc63567cf3886b3332b312a5b4585d8d3a6a610"
+
+[[package]]
+name = "cfg-if"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+
+[[package]]
+name = "either"
+version = "1.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e78d4f1cc4ae33bbfc157ed5d5a5ef3bc29227303d595861deb238fcec4e9457"
+
+[[package]]
+name = "fastrand"
+version = "1.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3fcf0cee53519c866c09b5de1f6c56ff9d647101f81c1964fa632e148896cdf"
+dependencies = [
+ "instant",
+]
+
+[[package]]
+name = "fnv"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
+name = "getrandom"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "418d37c8b1d42553c93648be529cb70f920d3baf8ef469b74b9638df426e0b4c"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "wasi",
+]
+
+[[package]]
 name = "hermit-abi"
 version = "0.1.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -13,16 +84,51 @@ dependencies = [
 
 [[package]]
 name = "hvm"
-version = "0.1.6"
+version = "0.1.7"
 dependencies = [
+ "itertools",
  "num_cpus",
+ "proptest",
 ]
+
+[[package]]
+name = "instant"
+version = "0.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a5bbe824c507c5da5956355e86a746d82e0e1464f65d862cc5e71da70e94b2c"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
+name = "itertools"
+version = "0.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a9a9d19fa1e79b6215ff29b9d6880b706147f16e9b1dbb1e4e5947b5b02bc5e3"
+dependencies = [
+ "either",
+]
+
+[[package]]
+name = "lazy_static"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
 version = "0.2.116"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "565dbd88872dbe4cc8a46e527f26483c1d1f7afa6b884a3bd6cd893d4f98da74"
+
+[[package]]
+name = "num-traits"
+version = "0.2.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a64b1ec5cda2586e284722486d802acf1f7dbdc623e2bfc57e65ca1cd099290"
+dependencies = [
+ "autocfg",
+]
 
 [[package]]
 name = "num_cpus"
@@ -33,3 +139,167 @@ dependencies = [
  "hermit-abi",
  "libc",
 ]
+
+[[package]]
+name = "ppv-lite86"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb9f9e6e233e5c4a35559a617bf40a4ec447db2e84c20b55a6f83167b7e57872"
+
+[[package]]
+name = "proptest"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e0d9cc07f18492d879586c92b485def06bc850da3118075cd45d50e9c95b0e5"
+dependencies = [
+ "bit-set",
+ "bitflags",
+ "byteorder",
+ "lazy_static",
+ "num-traits",
+ "quick-error 2.0.1",
+ "rand",
+ "rand_chacha",
+ "rand_xorshift",
+ "regex-syntax",
+ "rusty-fork",
+ "tempfile",
+]
+
+[[package]]
+name = "quick-error"
+version = "1.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
+
+[[package]]
+name = "quick-error"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a993555f31e5a609f617c12db6250dedcac1b0a85076912c436e6fc9b2c8e6a3"
+
+[[package]]
+name = "rand"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e7573632e6454cf6b99d7aac4ccca54be06da05aca2ef7423d22d27d4d4bcd8"
+dependencies = [
+ "libc",
+ "rand_chacha",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
+dependencies = [
+ "ppv-lite86",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d34f1408f55294453790c48b2f1ebbb1c5b4b7563eb1f418bcfcfdbb06ebb4e7"
+dependencies = [
+ "getrandom",
+]
+
+[[package]]
+name = "rand_xorshift"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d25bf25ec5ae4a3f1b92f929810509a2f53d7dca2f50b794ff57e3face536c8f"
+dependencies = [
+ "rand_core",
+]
+
+[[package]]
+name = "redox_syscall"
+version = "0.2.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8383f39639269cde97d255a32bdb68c047337295414940c68bdd30c2e13203ff"
+dependencies = [
+ "bitflags",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.6.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f497285884f3fcff424ffc933e56d7cbca511def0c9831a7f9b5f6153e3cc89b"
+
+[[package]]
+name = "remove_dir_all"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3acd125665422973a33ac9d3dd2df85edad0f4ae9b00dafb1a05e43a9f5ef8e7"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
+name = "rusty-fork"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb3dcc6e454c328bb824492db107ab7c0ae8fcffe4ad210136ef014458c1bc4f"
+dependencies = [
+ "fnv",
+ "quick-error 1.2.3",
+ "tempfile",
+ "wait-timeout",
+]
+
+[[package]]
+name = "tempfile"
+version = "3.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5cdb1ef4eaeeaddc8fbd371e5017057064af0911902ef36b39801f67cc6d79e4"
+dependencies = [
+ "cfg-if",
+ "fastrand",
+ "libc",
+ "redox_syscall",
+ "remove_dir_all",
+ "winapi",
+]
+
+[[package]]
+name = "wait-timeout"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f200f5b12eb75f8c1ed65abd4b2db8a6e1b138a20de009dacee265a2498f3f6"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "wasi"
+version = "0.10.2+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd6fbd9a79829dd1ad0cc20627bf1ed606756a7f77edff7b66b7064f9cb327c6"
+
+[[package]]
+name = "winapi"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
+dependencies = [
+ "winapi-i686-pc-windows-gnu",
+ "winapi-x86_64-pc-windows-gnu",
+]
+
+[[package]]
+name = "winapi-i686-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
+name = "winapi-x86_64-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"

--- a/Cargo.nix
+++ b/Cargo.nix
@@ -87,6 +87,172 @@ rec {
     #   inject test dependencies into the build
 
     crates = {
+      "autocfg" = rec {
+        crateName = "autocfg";
+        version = "1.0.1";
+        edition = "2015";
+        sha256 = "0jj6i9zn4gjl03kjvziqdji6rwx8ykz8zk2ngpc331z2g3fk3c6d";
+        authors = [
+          "Josh Stone <cuviper@gmail.com>"
+        ];
+
+      };
+      "bit-set" = rec {
+        crateName = "bit-set";
+        version = "0.5.2";
+        edition = "2015";
+        sha256 = "1pjrmpsnad5ipwjsv8ppi0qrhqvgpyn3wfbvk7jy8dga6mhf24bf";
+        authors = [
+          "Alexis Beingessner <a.beingessner@gmail.com>"
+        ];
+        dependencies = [
+          {
+            name = "bit-vec";
+            packageId = "bit-vec";
+            usesDefaultFeatures = false;
+          }
+        ];
+        features = {
+          "default" = [ "std" ];
+          "std" = [ "bit-vec/std" ];
+        };
+        resolvedDefaultFeatures = [ "default" "std" ];
+      };
+      "bit-vec" = rec {
+        crateName = "bit-vec";
+        version = "0.6.3";
+        edition = "2015";
+        sha256 = "1ywqjnv60cdh1slhz67psnp422md6jdliji6alq0gmly2xm9p7rl";
+        authors = [
+          "Alexis Beingessner <a.beingessner@gmail.com>"
+        ];
+        features = {
+          "default" = [ "std" ];
+          "serde_no_std" = [ "serde/alloc" ];
+          "serde_std" = [ "std" "serde/std" ];
+        };
+        resolvedDefaultFeatures = [ "std" ];
+      };
+      "bitflags" = rec {
+        crateName = "bitflags";
+        version = "1.3.2";
+        edition = "2018";
+        sha256 = "12ki6w8gn1ldq7yz9y680llwk5gmrhrzszaa17g1sbrw2r2qvwxy";
+        authors = [
+          "The Rust Project Developers"
+        ];
+        features = {
+          "rustc-dep-of-std" = [ "core" "compiler_builtins" ];
+        };
+        resolvedDefaultFeatures = [ "default" ];
+      };
+      "byteorder" = rec {
+        crateName = "byteorder";
+        version = "1.4.3";
+        edition = "2018";
+        sha256 = "0456lv9xi1a5bcm32arknf33ikv76p3fr9yzki4lb2897p2qkh8l";
+        authors = [
+          "Andrew Gallant <jamslam@gmail.com>"
+        ];
+        features = {
+          "default" = [ "std" ];
+        };
+        resolvedDefaultFeatures = [ "std" ];
+      };
+      "cfg-if" = rec {
+        crateName = "cfg-if";
+        version = "1.0.0";
+        edition = "2018";
+        sha256 = "1za0vb97n4brpzpv8lsbnzmq5r8f2b0cpqqr0sy8h5bn751xxwds";
+        authors = [
+          "Alex Crichton <alex@alexcrichton.com>"
+        ];
+        features = {
+          "rustc-dep-of-std" = [ "core" "compiler_builtins" ];
+        };
+      };
+      "either" = rec {
+        crateName = "either";
+        version = "1.6.1";
+        edition = "2015";
+        sha256 = "0mwl9vngqf5jvrhmhn9x60kr5hivxyjxbmby2pybncxfqhf4z3g7";
+        authors = [
+          "bluss"
+        ];
+        features = {
+          "default" = [ "use_std" ];
+        };
+      };
+      "fastrand" = rec {
+        crateName = "fastrand";
+        version = "1.7.0";
+        edition = "2018";
+        sha256 = "1pvci54f2cm69ybc308z213xdybgqpvf2pcvq1kch69mwp7g1z63";
+        authors = [
+          "Stjepan Glavina <stjepang@gmail.com>"
+        ];
+        dependencies = [
+          {
+            name = "instant";
+            packageId = "instant";
+            target = { target, features }: (target."arch" == "wasm32");
+          }
+        ];
+        devDependencies = [
+          {
+            name = "instant";
+            packageId = "instant";
+            target = {target, features}: (target."arch" == "wasm32");
+            features = [ "wasm-bindgen" ];
+          }
+        ];
+
+      };
+      "fnv" = rec {
+        crateName = "fnv";
+        version = "1.0.7";
+        edition = "2015";
+        sha256 = "1hc2mcqha06aibcaza94vbi81j6pr9a1bbxrxjfhc91zin8yr7iz";
+        libPath = "lib.rs";
+        authors = [
+          "Alex Crichton <alex@alexcrichton.com>"
+        ];
+        features = {
+          "default" = [ "std" ];
+        };
+        resolvedDefaultFeatures = [ "default" "std" ];
+      };
+      "getrandom" = rec {
+        crateName = "getrandom";
+        version = "0.2.4";
+        edition = "2018";
+        sha256 = "0k0bdr1dyf4n9fvnkx4fmwxhv4hgnyf55gj86v4m69fln743g3a1";
+        authors = [
+          "The Rand Project Developers"
+        ];
+        dependencies = [
+          {
+            name = "cfg-if";
+            packageId = "cfg-if";
+          }
+          {
+            name = "libc";
+            packageId = "libc";
+            usesDefaultFeatures = false;
+            target = { target, features }: (target."unix" or false);
+          }
+          {
+            name = "wasi";
+            packageId = "wasi";
+            target = { target, features }: (target."os" == "wasi");
+          }
+        ];
+        features = {
+          "js" = [ "wasm-bindgen" "js-sys" ];
+          "rustc-dep-of-std" = [ "compiler_builtins" "core" "libc/rustc-dep-of-std" "wasi/rustc-dep-of-std" ];
+        };
+        resolvedDefaultFeatures = [ "std" ];
+      };
       "hermit-abi" = rec {
         crateName = "hermit-abi";
         version = "0.1.19";
@@ -109,7 +275,7 @@ rec {
       };
       "hvm" = rec {
         crateName = "hvm";
-        version = "0.1.6";
+        version = "0.1.7";
         edition = "2021";
         crateBin = [
           { name = "hvm"; path = "src/main.rs"; }
@@ -117,11 +283,72 @@ rec {
         src = lib.cleanSourceWith { filter = sourceFilter;  src = ./.; };
         dependencies = [
           {
+            name = "itertools";
+            packageId = "itertools";
+          }
+          {
             name = "num_cpus";
             packageId = "num_cpus";
           }
         ];
+        devDependencies = [
+          {
+            name = "proptest";
+            packageId = "proptest";
+          }
+        ];
 
+      };
+      "instant" = rec {
+        crateName = "instant";
+        version = "0.1.12";
+        edition = "2018";
+        sha256 = "0b2bx5qdlwayriidhrag8vhy10kdfimfhmb3jnjmsz2h9j1bwnvs";
+        authors = [
+          "sebcrozet <developer@crozet.re>"
+        ];
+        dependencies = [
+          {
+            name = "cfg-if";
+            packageId = "cfg-if";
+          }
+        ];
+        features = {
+          "wasm-bindgen" = [ "js-sys" "wasm-bindgen_rs" "web-sys" ];
+        };
+      };
+      "itertools" = rec {
+        crateName = "itertools";
+        version = "0.10.3";
+        edition = "2018";
+        sha256 = "1qy55fqbaisr9qgbn7cvdvqlfqbh1f4ddf99zwan56z7l6gx3ad9";
+        authors = [
+          "bluss"
+        ];
+        dependencies = [
+          {
+            name = "either";
+            packageId = "either";
+            usesDefaultFeatures = false;
+          }
+        ];
+        features = {
+          "default" = [ "use_std" ];
+          "use_std" = [ "use_alloc" ];
+        };
+        resolvedDefaultFeatures = [ "default" "use_alloc" "use_std" ];
+      };
+      "lazy_static" = rec {
+        crateName = "lazy_static";
+        version = "1.4.0";
+        edition = "2015";
+        sha256 = "0in6ikhw8mgl33wjv6q6xfrb5b9jr16q8ygjy803fay4zcisvaz2";
+        authors = [
+          "Marvin Löbel <loebel.marvin@gmail.com>"
+        ];
+        features = {
+          "spin_no_std" = [ "spin" ];
+        };
       };
       "libc" = rec {
         crateName = "libc";
@@ -137,6 +364,25 @@ rec {
           "use_std" = [ "std" ];
         };
         resolvedDefaultFeatures = [ "default" "std" ];
+      };
+      "num-traits" = rec {
+        crateName = "num-traits";
+        version = "0.2.14";
+        edition = "2015";
+        sha256 = "144j176s2p76azy2ngk2vkdzgwdc0bc8c93jhki8c9fsbknb2r4s";
+        authors = [
+          "The Rust Project Developers"
+        ];
+        buildDependencies = [
+          {
+            name = "autocfg";
+            packageId = "autocfg";
+          }
+        ];
+        features = {
+          "default" = [ "std" ];
+        };
+        resolvedDefaultFeatures = [ "std" ];
       };
       "num_cpus" = rec {
         crateName = "num_cpus";
@@ -157,6 +403,434 @@ rec {
             packageId = "libc";
             target = { target, features }: (!(target."windows" or false));
           }
+        ];
+
+      };
+      "ppv-lite86" = rec {
+        crateName = "ppv-lite86";
+        version = "0.2.16";
+        edition = "2018";
+        sha256 = "0wkqwnvnfcgqlrahphl45vdlgi2f1bs7nqcsalsllp1y4dp9x7zb";
+        authors = [
+          "The CryptoCorrosion Contributors"
+        ];
+        features = {
+          "default" = [ "std" ];
+        };
+        resolvedDefaultFeatures = [ "simd" "std" ];
+      };
+      "proptest" = rec {
+        crateName = "proptest";
+        version = "1.0.0";
+        edition = "2018";
+        sha256 = "1rdhjnf0xma5rmsq04d31n2vq1pgbm42pjc6jn3jsj8qgz09q38y";
+        authors = [
+          "Jason Lingle"
+        ];
+        dependencies = [
+          {
+            name = "bit-set";
+            packageId = "bit-set";
+            optional = true;
+          }
+          {
+            name = "bitflags";
+            packageId = "bitflags";
+          }
+          {
+            name = "byteorder";
+            packageId = "byteorder";
+            usesDefaultFeatures = false;
+          }
+          {
+            name = "lazy_static";
+            packageId = "lazy_static";
+            optional = true;
+          }
+          {
+            name = "num-traits";
+            packageId = "num-traits";
+            usesDefaultFeatures = false;
+          }
+          {
+            name = "quick-error";
+            packageId = "quick-error 2.0.1";
+            optional = true;
+          }
+          {
+            name = "rand";
+            packageId = "rand";
+            usesDefaultFeatures = false;
+            features = [ "alloc" ];
+          }
+          {
+            name = "rand_chacha";
+            packageId = "rand_chacha";
+            usesDefaultFeatures = false;
+          }
+          {
+            name = "rand_xorshift";
+            packageId = "rand_xorshift";
+          }
+          {
+            name = "regex-syntax";
+            packageId = "regex-syntax";
+            optional = true;
+          }
+          {
+            name = "rusty-fork";
+            packageId = "rusty-fork";
+            optional = true;
+            usesDefaultFeatures = false;
+          }
+          {
+            name = "tempfile";
+            packageId = "tempfile";
+            optional = true;
+          }
+        ];
+        features = {
+          "default" = [ "std" "fork" "timeout" "bit-set" "break-dead-code" ];
+          "default-code-coverage" = [ "std" "fork" "timeout" "bit-set" ];
+          "fork" = [ "std" "rusty-fork" "tempfile" ];
+          "hardware-rng" = [ "x86" ];
+          "std" = [ "rand/std" "byteorder/std" "lazy_static" "quick-error" "regex-syntax" "num-traits/std" ];
+          "timeout" = [ "fork" "rusty-fork/timeout" ];
+        };
+        resolvedDefaultFeatures = [ "bit-set" "break-dead-code" "default" "fork" "lazy_static" "quick-error" "regex-syntax" "rusty-fork" "std" "tempfile" "timeout" ];
+      };
+      "quick-error 1.2.3" = rec {
+        crateName = "quick-error";
+        version = "1.2.3";
+        edition = "2015";
+        sha256 = "1q6za3v78hsspisc197bg3g7rpc989qycy8ypr8ap8igv10ikl51";
+        authors = [
+          "Paul Colomiets <paul@colomiets.name>"
+          "Colin Kiegel <kiegel@gmx.de>"
+        ];
+
+      };
+      "quick-error 2.0.1" = rec {
+        crateName = "quick-error";
+        version = "2.0.1";
+        edition = "2018";
+        sha256 = "18z6r2rcjvvf8cn92xjhm2qc3jpd1ljvcbf12zv0k9p565gmb4x9";
+        authors = [
+          "Paul Colomiets <paul@colomiets.name>"
+          "Colin Kiegel <kiegel@gmx.de>"
+        ];
+
+      };
+      "rand" = rec {
+        crateName = "rand";
+        version = "0.8.4";
+        edition = "2018";
+        sha256 = "1n5wska2fbfj4dsfz8mc0pd0dgjlrb6c9anpk5mwym345rip6x9f";
+        authors = [
+          "The Rand Project Developers"
+          "The Rust Project Developers"
+        ];
+        dependencies = [
+          {
+            name = "libc";
+            packageId = "libc";
+            optional = true;
+            usesDefaultFeatures = false;
+            target = { target, features }: (target."unix" or false);
+          }
+          {
+            name = "rand_chacha";
+            packageId = "rand_chacha";
+            optional = true;
+            usesDefaultFeatures = false;
+            target = { target, features }: (!(target."os" == "emscripten"));
+          }
+          {
+            name = "rand_core";
+            packageId = "rand_core";
+          }
+        ];
+        features = {
+          "alloc" = [ "rand_core/alloc" ];
+          "default" = [ "std" "std_rng" ];
+          "getrandom" = [ "rand_core/getrandom" ];
+          "serde1" = [ "serde" "rand_core/serde1" ];
+          "simd_support" = [ "packed_simd" ];
+          "std" = [ "rand_core/std" "rand_chacha/std" "alloc" "getrandom" "libc" ];
+          "std_rng" = [ "rand_chacha" "rand_hc" ];
+        };
+        resolvedDefaultFeatures = [ "alloc" "getrandom" "libc" "rand_chacha" "std" ];
+      };
+      "rand_chacha" = rec {
+        crateName = "rand_chacha";
+        version = "0.3.1";
+        edition = "2018";
+        sha256 = "123x2adin558xbhvqb8w4f6syjsdkmqff8cxwhmjacpsl1ihmhg6";
+        authors = [
+          "The Rand Project Developers"
+          "The Rust Project Developers"
+          "The CryptoCorrosion Contributors"
+        ];
+        dependencies = [
+          {
+            name = "ppv-lite86";
+            packageId = "ppv-lite86";
+            usesDefaultFeatures = false;
+            features = [ "simd" ];
+          }
+          {
+            name = "rand_core";
+            packageId = "rand_core";
+          }
+        ];
+        features = {
+          "default" = [ "std" ];
+          "serde1" = [ "serde" ];
+          "std" = [ "ppv-lite86/std" ];
+        };
+        resolvedDefaultFeatures = [ "std" ];
+      };
+      "rand_core" = rec {
+        crateName = "rand_core";
+        version = "0.6.3";
+        edition = "2018";
+        sha256 = "1rxlxc3bpzgwphcg9c9yasvv9idipcg2z2y4j0vlb52jyl418kyk";
+        authors = [
+          "The Rand Project Developers"
+          "The Rust Project Developers"
+        ];
+        dependencies = [
+          {
+            name = "getrandom";
+            packageId = "getrandom";
+            optional = true;
+          }
+        ];
+        features = {
+          "serde1" = [ "serde" ];
+          "std" = [ "alloc" "getrandom" "getrandom/std" ];
+        };
+        resolvedDefaultFeatures = [ "alloc" "getrandom" "std" ];
+      };
+      "rand_xorshift" = rec {
+        crateName = "rand_xorshift";
+        version = "0.3.0";
+        edition = "2018";
+        sha256 = "13vcag7gmqspzyabfl1gr9ykvxd2142q2agrj8dkyjmfqmgg4nyj";
+        authors = [
+          "The Rand Project Developers"
+          "The Rust Project Developers"
+        ];
+        dependencies = [
+          {
+            name = "rand_core";
+            packageId = "rand_core";
+          }
+        ];
+        features = {
+          "serde1" = [ "serde" ];
+        };
+      };
+      "redox_syscall" = rec {
+        crateName = "redox_syscall";
+        version = "0.2.10";
+        edition = "2018";
+        sha256 = "1zq36bhw4c6xig340ja1jmr36iy0d3djp8smsabxx71676bg70w3";
+        libName = "syscall";
+        authors = [
+          "Jeremy Soller <jackpot51@gmail.com>"
+        ];
+        dependencies = [
+          {
+            name = "bitflags";
+            packageId = "bitflags";
+          }
+        ];
+
+      };
+      "regex-syntax" = rec {
+        crateName = "regex-syntax";
+        version = "0.6.25";
+        edition = "2018";
+        sha256 = "16y87hz1bxmmz6kk360cxwfm3jnbsxb3x4zw9x1gzz7khic2i5zl";
+        authors = [
+          "The Rust Project Developers"
+        ];
+        features = {
+          "default" = [ "unicode" ];
+          "unicode" = [ "unicode-age" "unicode-bool" "unicode-case" "unicode-gencat" "unicode-perl" "unicode-script" "unicode-segment" ];
+        };
+        resolvedDefaultFeatures = [ "default" "unicode" "unicode-age" "unicode-bool" "unicode-case" "unicode-gencat" "unicode-perl" "unicode-script" "unicode-segment" ];
+      };
+      "remove_dir_all" = rec {
+        crateName = "remove_dir_all";
+        version = "0.5.3";
+        edition = "2015";
+        sha256 = "1rzqbsgkmr053bxxl04vmvsd1njyz0nxvly97aip6aa2cmb15k9s";
+        authors = [
+          "Aaronepower <theaaronepower@gmail.com>"
+        ];
+        dependencies = [
+          {
+            name = "winapi";
+            packageId = "winapi";
+            target = { target, features }: (target."windows" or false);
+            features = [ "std" "errhandlingapi" "winerror" "fileapi" "winbase" ];
+          }
+        ];
+
+      };
+      "rusty-fork" = rec {
+        crateName = "rusty-fork";
+        version = "0.3.0";
+        edition = "2018";
+        sha256 = "0kxwq5c480gg6q0j3bg4zzyfh2kwmc3v2ba94jw8ncjc8mpcqgfb";
+        authors = [
+          "Jason Lingle"
+        ];
+        dependencies = [
+          {
+            name = "fnv";
+            packageId = "fnv";
+          }
+          {
+            name = "quick-error";
+            packageId = "quick-error 1.2.3";
+          }
+          {
+            name = "tempfile";
+            packageId = "tempfile";
+          }
+          {
+            name = "wait-timeout";
+            packageId = "wait-timeout";
+            optional = true;
+          }
+        ];
+        features = {
+          "default" = [ "timeout" ];
+          "timeout" = [ "wait-timeout" ];
+        };
+        resolvedDefaultFeatures = [ "timeout" "wait-timeout" ];
+      };
+      "tempfile" = rec {
+        crateName = "tempfile";
+        version = "3.3.0";
+        edition = "2018";
+        sha256 = "1r3rdp66f7w075mz6blh244syr3h0lbm07ippn7xrbgfxbs1xnsw";
+        authors = [
+          "Steven Allen <steven@stebalien.com>"
+          "The Rust Project Developers"
+          "Ashley Mannix <ashleymannix@live.com.au>"
+          "Jason White <jasonaw0@gmail.com>"
+        ];
+        dependencies = [
+          {
+            name = "cfg-if";
+            packageId = "cfg-if";
+          }
+          {
+            name = "fastrand";
+            packageId = "fastrand";
+          }
+          {
+            name = "libc";
+            packageId = "libc";
+            target = { target, features }: ((target."unix" or false) || (target."os" == "wasi"));
+          }
+          {
+            name = "redox_syscall";
+            packageId = "redox_syscall";
+            target = { target, features }: (target."os" == "redox");
+          }
+          {
+            name = "remove_dir_all";
+            packageId = "remove_dir_all";
+          }
+          {
+            name = "winapi";
+            packageId = "winapi";
+            target = { target, features }: (target."windows" or false);
+            features = [ "fileapi" "handleapi" "winbase" ];
+          }
+        ];
+        features = {
+        };
+      };
+      "wait-timeout" = rec {
+        crateName = "wait-timeout";
+        version = "0.2.0";
+        edition = "2015";
+        crateBin = [];
+        sha256 = "1xpkk0j5l9pfmjfh1pi0i89invlavfrd9av5xp0zhxgb29dhy84z";
+        authors = [
+          "Alex Crichton <alex@alexcrichton.com>"
+        ];
+        dependencies = [
+          {
+            name = "libc";
+            packageId = "libc";
+            target = { target, features }: (target."unix" or false);
+          }
+        ];
+
+      };
+      "wasi" = rec {
+        crateName = "wasi";
+        version = "0.10.2+wasi-snapshot-preview1";
+        edition = "2018";
+        sha256 = "1ii7nff4y1mpcrxzzvbpgxm7a1nn3szjf1n21jnx37c2g6dbsvzx";
+        authors = [
+          "The Cranelift Project Developers"
+        ];
+        features = {
+          "default" = [ "std" ];
+          "rustc-dep-of-std" = [ "compiler_builtins" "core" "rustc-std-workspace-alloc" ];
+        };
+        resolvedDefaultFeatures = [ "default" "std" ];
+      };
+      "winapi" = rec {
+        crateName = "winapi";
+        version = "0.3.9";
+        edition = "2015";
+        sha256 = "06gl025x418lchw1wxj64ycr7gha83m44cjr5sarhynd9xkrm0sw";
+        authors = [
+          "Peter Atashian <retep998@gmail.com>"
+        ];
+        dependencies = [
+          {
+            name = "winapi-i686-pc-windows-gnu";
+            packageId = "winapi-i686-pc-windows-gnu";
+            target = { target, features }: (stdenv.hostPlatform.config == "i686-pc-windows-gnu");
+          }
+          {
+            name = "winapi-x86_64-pc-windows-gnu";
+            packageId = "winapi-x86_64-pc-windows-gnu";
+            target = { target, features }: (stdenv.hostPlatform.config == "x86_64-pc-windows-gnu");
+          }
+        ];
+        features = {
+          "debug" = [ "impl-debug" ];
+        };
+        resolvedDefaultFeatures = [ "errhandlingapi" "fileapi" "handleapi" "std" "winbase" "winerror" ];
+      };
+      "winapi-i686-pc-windows-gnu" = rec {
+        crateName = "winapi-i686-pc-windows-gnu";
+        version = "0.4.0";
+        edition = "2015";
+        sha256 = "1dmpa6mvcvzz16zg6d5vrfy4bxgg541wxrcip7cnshi06v38ffxc";
+        authors = [
+          "Peter Atashian <retep998@gmail.com>"
+        ];
+
+      };
+      "winapi-x86_64-pc-windows-gnu" = rec {
+        crateName = "winapi-x86_64-pc-windows-gnu";
+        version = "0.4.0";
+        edition = "2015";
+        sha256 = "0gqq64czqb64kskjryj8isp62m2sgvx25yyj3kpc2myh85w24bki";
+        authors = [
+          "Peter Atashian <retep998@gmail.com>"
         ];
 
       };

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,4 +18,8 @@ name = "hvm"
 test = false
 
 [dependencies]
+itertools = "0.10"
 num_cpus = "1.13"
+
+[dev-dependencies]
+proptest = "1.0"

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -26,6 +26,7 @@
 // Check the Testree example at the bottom of this file.
 
 #![allow(dead_code)]
+use itertools::Itertools;
 
 // Types
 // =====
@@ -37,8 +38,8 @@ pub struct State<'a> {
 }
 
 impl<'a> State<'a> {
-  fn rest(&self) -> &'a str {
-    &self.code[self.index..]
+  fn rest(&self) -> Option<&'a str> {
+    self.code.get(self.index..)
   }
 }
 
@@ -48,25 +49,13 @@ pub type Parser<'a, A> = Box<dyn Fn(State<'a>) -> Answer<'a, A>>;
 // Utils
 // =====
 
-pub fn equal_at(text: &str, test: &str, i: usize) -> bool {
-  return &text.as_bytes()[i..std::cmp::min(text.len(), i + test.len())] == test.as_bytes();
-}
-
-pub fn flatten(texts: &[&str]) -> String {
-  texts.concat()
-}
-
-pub fn lines(text: &str) -> Vec<String> {
-  text.lines().map(String::from).collect()
-}
-
 pub fn find(text: &str, target: &str) -> usize {
-  text.find(target).unwrap()
+  text.find(target).unwrap_or_else(|| panic!("`{}` not in `{}`.", target, text))
 }
 
 pub fn read<'a, A>(parser: Parser<'a, A>, code: &'a str) -> A {
   match parser(State { code, index: 0 }) {
-    Ok((_state, value)) => value,
+    Ok((_, value)) => value,
     Err(msg) => {
       println!("{}", msg);
       panic!("No parse.");
@@ -77,28 +66,25 @@ pub fn read<'a, A>(parser: Parser<'a, A>, code: &'a str) -> A {
 // Elims
 // =====
 
+/// Maybe gets the current character.
 pub fn head(state: State) -> Option<char> {
-  return state.code[state.index..].chars().next();
+  state.rest()?.chars().next()
 }
 
-pub fn head_default(state: State) -> char {
-  if let Some(got) = head(state) {
-    got
-  } else {
-    '\0'
-  }
-}
-
+/// Skips the current character.
 pub fn tail(state: State) -> State {
   let add = match head(state) {
     Some(c) => c.len_utf8(),
     None => 0,
   };
+  // NOTE: Could just mutate `state.index` here?
   State { code: state.code, index: state.index + add }
 }
 
+/// Skips comments and whitespace, then returns the next `char`, or the null
+/// character if this doesn't exist.
 pub fn get_char(state: State) -> Answer<char> {
-  let (state, _skipped) = skip(state)?;
+  let (state, _) = skip(state)?;
   if let Some(got) = head(state) {
     let state = State { code: state.code, index: state.index + got.len_utf8() };
     Ok((state, got))
@@ -114,52 +100,58 @@ pub fn get_char_parser<'a>() -> Parser<'a, char> {
 // Skippers
 // ========
 
-pub fn skip_comment(state: State) -> Answer<bool> {
-  let mut state = state;
-  if state.index + 1 < state.code.len() && equal_at(state.code, "//", state.index) {
-    state.index += 2;
-    while state.index < state.code.len() && !equal_at(state.code, "\n", state.index) {
-      state.index += 1;
+pub fn skip_comment(mut state: State) -> Answer<bool> {
+  const COMMENT: &str = "//";
+  if let Some(rest) = state.rest() {
+    if let Some(line) = rest.lines().next() {
+      if line.starts_with(COMMENT) {
+        state.index += line.len();
+        return Ok((state, true));
+      }
     }
-    Ok((state, true))
-  } else {
-    Ok((state, false))
   }
+  Ok((state, false))
 }
 
 pub fn skip_comment_parser<'a>() -> Parser<'a, bool> {
   Box::new(skip_comment)
 }
 
-pub fn skip_spaces(state: State) -> Answer<bool> {
-  pub fn is_space(chr: char) -> bool {
-    chr == ' ' || chr == '\n' || chr == '\t' || chr == '\r'
-  }
-  let mut state = state;
-  if state.index < state.code.len() && is_space(head_default(state)) {
-    state.index += 1;
-    while state.index < state.code.len() && is_space(head_default(state)) {
-      state.index += 1;
+pub fn skip_spaces(mut state: State) -> Answer<bool> {
+  if let Some(rest) = state.rest() {
+    let add: usize = rest.chars().take_while(|a| a.is_whitespace()).map(|a| a.len_utf8()).sum();
+    state.index += add;
+    if add > 0 {
+      return Ok((state, true));
     }
-    Ok((state, true))
-  } else {
-    Ok((state, false))
   }
+  Ok((state, false))
 }
 
 pub fn skip_spaces_parser<'a>() -> Parser<'a, bool> {
   Box::new(skip_spaces)
 }
 
-pub fn skip(state: State) -> Answer<bool> {
-  let (state, comment) = skip_comment(state)?;
-  let (state, spaces) = skip_spaces(state)?;
+/// Skips comments and whitespace.
+pub fn skip(mut state: State) -> Answer<bool> {
+  let (new_state, mut comment) = skip_comment(state)?;
+  state = new_state;
+  let (new_state, mut spaces) = skip_spaces(state)?;
+  state = new_state;
   if comment || spaces {
-    let (state, _skipped) = skip(state)?;
-    Ok((state, true))
-  } else {
-    Ok((state, false))
+    loop {
+      let (new_state, new_comment) = skip_comment(state)?;
+      state = new_state;
+      comment = new_comment;
+      let (new_state, new_spaces) = skip_spaces(state)?;
+      state = new_state;
+      spaces = new_spaces;
+      if !comment && !spaces {
+        return Ok((state, true));
+      }
+    }
   }
+  Ok((state, false))
 }
 
 pub fn skip_parser<'a>() -> Parser<'a, bool> {
@@ -169,24 +161,25 @@ pub fn skip_parser<'a>() -> Parser<'a, bool> {
 // Strings
 // =======
 
-// Attempts to match a string right after the cursor.
-// Returns true if successful. Consumes string.
+/// Attempts to match a string right after the cursor.
+/// Returns `true` if successful. Consumes string.
 pub fn text_here<'a>(pat: &str, state: State<'a>) -> Answer<'a, bool> {
-  if equal_at(state.code, pat, state.index) {
-    let state = State { code: state.code, index: state.index + pat.len() };
-    Ok((state, true))
-  } else {
-    Ok((state, false))
+  if let Some(rest) = state.rest() {
+    if rest.starts_with(pat) {
+      let state = State { code: state.code, index: state.index + pat.len() };
+      return Ok((state, true));
+    }
   }
+  Ok((state, false))
 }
 
 pub fn text_here_parser<'a>(pat: &'static str) -> Parser<'a, bool> {
   Box::new(move |x| text_here(pat, x))
 }
 
-// Like 'text_here', but skipping spaces and comments before.
+/// Like 'text_here', but skips whitespace and comments first.
 pub fn text<'a>(pat: &str, state: State<'a>) -> Answer<'a, bool> {
-  let (state, _skipped) = skip(state)?;
+  let (state, _) = skip(state)?;
   let (state, matched) = text_here(pat, state)?;
   Ok((state, matched))
 }
@@ -195,7 +188,7 @@ pub fn text_parser<'a>(pat: &'static str) -> Parser<'a, bool> {
   Box::new(move |x| text(pat, x))
 }
 
-// Like 'text', but aborts if there is no match.
+/// Like 'text', but aborts if there is no match.
 pub fn consume<'a>(pat: &str, state: State<'a>) -> Answer<'a, ()> {
   let (state, matched) = text(pat, state)?;
   if matched {
@@ -209,9 +202,9 @@ pub fn consume_parser<'a>(pat: &'static str) -> Parser<'a, ()> {
   Box::new(move |x| consume(pat, x))
 }
 
-// Returns true if we are at the end of the file, skipping spaces and comments.
+/// Returns `true` if cursor will be at the end of the file after skipping whitespace and comments.
 pub fn done(state: State) -> Answer<bool> {
-  let (state, _skipped) = skip(state)?;
+  let (state, _) = skip(state)?;
   Ok((state, state.index == state.code.len()))
 }
 
@@ -222,15 +215,15 @@ pub fn done_parser<'a>() -> Parser<'a, bool> {
 // Blocks
 // ======
 
-// Checks if a dry-run of the first parser returns true.
-// If so, applies the second parser, returning Some.
-// If no, return None.
+/// Checks if a dry-run of the first parser returns `true`.
+/// If so, applies the second parser and returns `Some`.
+/// If no, returns `None`.
 pub fn guard<'a, A: 'a>(
   head: Parser<'a, bool>,
   body: Parser<'a, A>,
   state: State<'a>,
 ) -> Answer<'a, Option<A>> {
-  let (state, _skipped) = skip(state)?;
+  let (state, _) = skip(state)?;
   let (_, matched) = head(state)?;
   if matched {
     let (state, got) = body(state)?;
@@ -240,9 +233,9 @@ pub fn guard<'a, A: 'a>(
   }
 }
 
-// Applies optional parsers in sequence.
-// Returns the first that succeeds.
-// If none succeeds, aborts.
+/// Applies optional parsers in sequence.
+/// Returns the first that succeeds.
+/// Aborts if none succeed.
 pub fn grammar<'a, A: 'a>(
   name: &'static str,
   choices: &[Parser<'a, Option<A>>],
@@ -268,13 +261,13 @@ pub fn maybe<'a, A: 'a>(parser: Parser<'a, A>, state: State<'a>) -> Answer<'a, O
   }
 }
 
-// Evaluates a parser and returns its result, but reverts its effect.
+/// Evaluates a parser and returns its result, but reverts its effect.
 pub fn dry<'a, A: 'a>(parser: Parser<'a, A>, state: State<'a>) -> Answer<'a, A> {
-  let (_new_state, result) = parser(state)?;
+  let (_, result) = parser(state)?;
   Ok((state, result))
 }
 
-// Evaluates a parser until a condition is met. Returns an array of results.
+/// Evaluates a parser until a condition is met. Returns an array of results.
 pub fn until<'a, A: 'a>(
   delim: Parser<'a, bool>,
   parser: Parser<'a, A>,
@@ -296,7 +289,7 @@ pub fn until<'a, A: 'a>(
   Ok((state, result))
 }
 
-// Evaluates a list-like parser, with an opener, separator, and closer.
+/// Evaluates a list-like parser, with an opener, separator, and closer.
 pub fn list<'a, A: 'a, B: 'a>(
   parse_open: Parser<'a, bool>,
   parse_sep: Parser<'a, bool>,
@@ -326,16 +319,12 @@ pub fn list<'a, A: 'a, B: 'a>(
 // Name
 // ====
 
-// Is this character a valid name letter?
+/// Checks if input is a valid character for names.
 fn is_letter(chr: char) -> bool {
-  ('A'..='Z').contains(&chr)
-    || ('a'..='z').contains(&chr)
-    || ('0'..='9').contains(&chr)
-    || chr == '_'
-    || chr == '.'
+  chr.is_ascii_alphanumeric() || chr == '_' || chr == '.'
 }
 
-// Parses a name right after the parsing cursor.
+/// Parses a name right after the parsing cursor.
 pub fn name_here(state: State) -> Answer<String> {
   let mut name: String = String::new();
   let mut state = state;
@@ -350,13 +339,13 @@ pub fn name_here(state: State) -> Answer<String> {
   Ok((state, name))
 }
 
-// Parses a name after skipping.
+/// Parses a name after skipping comments and whitespace.
 pub fn name(state: State) -> Answer<String> {
-  let (state, _skipped) = skip(state)?;
+  let (state, _) = skip(state)?;
   name_here(state)
 }
 
-// Parses a non-empty name after skipping.
+/// Parses a non-empty name after skipping.
 pub fn name1(state: State) -> Answer<String> {
   let (state, name1) = name(state)?;
   if !name1.is_empty() {
@@ -370,14 +359,15 @@ pub fn name1(state: State) -> Answer<String> {
 // ======
 
 pub fn expected<'a, A>(name: &str, size: usize, state: State<'a>) -> Answer<'a, A> {
-  return Err(format!(
-    "Expected {}:\n{}",
-    name,
-    &highlight(state.index, state.index + size, state.code)
-  ));
+  Err(format!("Expected {}:\n{}", name, &highlight(state.index, state.index + size, state.code)))
 }
 
+// WARN: This fails if `from_index` or `to_index` are not `char` boundaries.
+// Should probably not use slice indexing directly, maybe use `get` method and
+// handle possible error instead?
 pub fn highlight(from_index: usize, to_index: usize, code: &str) -> String {
+  debug_assert!(to_index >= from_index);
+  debug_assert!(code.get(from_index..to_index).is_some());
   //let open = "<<<<####";
   //let close = "####>>>>";
   let open = "««««";
@@ -386,63 +376,59 @@ pub fn highlight(from_index: usize, to_index: usize, code: &str) -> String {
   let close_color = "\x1b[0m";
   let mut from_line = 0;
   let mut to_line = 0;
-  for (i, c) in code.chars().enumerate() {
-    if c == '\n' {
-      if i < from_index {
-        from_line += 1;
-      }
-      if i < to_index {
-        to_line += 1;
-      }
+  for (i, c) in
+    code.chars().enumerate().filter(|(_, c)| c == &'\n').take_while(|(i, _)| i < &to_index)
+  {
+    if i < from_index {
+      from_line += c.len_utf8();
     }
+    to_line += c.len_utf8();
   }
-  let code: String = flatten(&[
-    &code[0..from_index],
-    open,
-    &code[from_index..to_index],
-    close,
-    &code[to_index..code.len()],
-  ]);
-  let lines: Vec<String> = lines(&code);
+  let code =
+    [&code[0..from_index], open, &code[from_index..to_index], close, &code[to_index..code.len()]]
+      .concat();
   let block_from_line = std::cmp::max(from_line as i64 - 3, 0) as usize;
-  let block_to_line = std::cmp::min(to_line + 3, lines.len());
-  let mut text = String::new();
-  for (i, line) in lines[block_from_line..block_to_line].iter().enumerate() {
-    let numb = block_from_line + i;
-    let rest;
-    if numb == from_line && numb == to_line {
-      rest = flatten(&[
-        &line[0..find(line, open)],
-        open_color,
-        &line[find(line, open) + open.len()..find(line, close)],
-        close_color,
-        &line[find(line, close) + close.len()..line.len()],
-        "\n",
-      ]);
-    } else if numb == from_line {
-      rest = flatten(&[
-        &line[0..find(line, open)],
-        open_color,
-        &line[find(line, open)..line.len()],
-        "\n",
-      ]);
-    } else if numb > from_line && numb < to_line {
-      rest = flatten(&[open_color, line, close_color, "\n"]);
-    } else if numb == to_line {
-      rest = flatten(&[
-        &line[0..find(line, open)],
-        open_color,
-        &line[find(line, open)..find(line, close) + close.len()],
-        close_color,
-        "\n",
-      ]);
-    } else {
-      rest = flatten(&[line, "\n"]);
-    }
-    let line = format!("    {} | {}", numb, rest);
-    text.push_str(&line);
-  }
-  text
+  let block_to_line = std::cmp::min(to_line + 3, code.lines().count());
+  code
+    .lines()
+    .enumerate()
+    .skip_while(|(i, _)| i < &block_from_line)
+    .take_while(|(i, _)| i < &block_to_line)
+    .map(|(_, line)| line)
+    .enumerate()
+    .format_with("", |(i, line), f| {
+      let numb = block_from_line + i;
+      // TODO: An allocation of an intermediate string still occurs here
+      // which is inefficient. Should figure out how to improve this.
+      let rest = if numb == from_line && numb == to_line {
+        [
+          &line[0..find(line, open)],
+          open_color,
+          &line[find(line, open) + open.len()..find(line, close)],
+          close_color,
+          &line[find(line, close) + close.len()..line.len()],
+          "\n",
+        ]
+        .concat()
+      } else if numb == from_line {
+        [&line[0..find(line, open)], open_color, &line[find(line, open)..line.len()], "\n"].concat()
+      } else if numb > from_line && numb < to_line {
+        [open_color, line, close_color, "\n"].concat()
+      } else if numb == to_line {
+        [
+          &line[0..find(line, open)],
+          open_color,
+          &line[find(line, open)..find(line, close) + close.len()],
+          close_color,
+          "\n",
+        ]
+        .concat()
+      } else {
+        [line, "\n"].concat()
+      };
+      f(&format_args!("    {} | {}", numb, rest))
+    })
+    .to_string()
 }
 
 // Tests
@@ -494,4 +480,294 @@ pub fn testree_parser<'a>() -> Parser<'a, Box<Testree>> {
     let (state, tree) = grammar("Testree", &[node_parser(), leaf_parser()], state)?;
     Ok((state, tree))
   })
+}
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+  use proptest::prelude::*;
+
+  mod old_parser {
+    use super::super::*;
+
+    pub fn flatten(texts: &[&str]) -> String {
+      texts.concat()
+    }
+
+    pub fn lines(text: &str) -> Vec<String> {
+      text.lines().map(String::from).collect()
+    }
+
+    pub fn highlight(from_index: usize, to_index: usize, code: &str) -> String {
+      //let open = "<<<<####";
+      //let close = "####>>>>";
+      let open = "««««";
+      let close = "»»»»";
+      let open_color = "\x1b[4m\x1b[31m";
+      let close_color = "\x1b[0m";
+      let mut from_line = 0;
+      let mut to_line = 0;
+      for (i, c) in code.chars().enumerate() {
+        if c == '\n' {
+          if i < from_index {
+            from_line += 1;
+          }
+          if i < to_index {
+            to_line += 1;
+          }
+        }
+      }
+      let code: String = flatten(&[
+        &code[0..from_index],
+        open,
+        &code[from_index..to_index],
+        close,
+        &code[to_index..code.len()],
+      ]);
+      let lines: Vec<String> = lines(&code);
+      let block_from_line = std::cmp::max(from_line as i64 - 3, 0) as usize;
+      let block_to_line = std::cmp::min(to_line + 3, lines.len());
+      let mut text = String::new();
+      for (i, line) in lines[block_from_line..block_to_line].iter().enumerate() {
+        let numb = block_from_line + i;
+        let rest;
+        if numb == from_line && numb == to_line {
+          rest = flatten(&[
+            &line[0..find(line, open)],
+            open_color,
+            &line[find(line, open) + open.len()..find(line, close)],
+            close_color,
+            &line[find(line, close) + close.len()..line.len()],
+            "\n",
+          ]);
+        } else if numb == from_line {
+          rest = flatten(&[
+            &line[0..find(line, open)],
+            open_color,
+            &line[find(line, open)..line.len()],
+            "\n",
+          ]);
+        } else if numb > from_line && numb < to_line {
+          rest = flatten(&[open_color, line, close_color, "\n"]);
+        } else if numb == to_line {
+          rest = flatten(&[
+            &line[0..find(line, open)],
+            open_color,
+            &line[find(line, open)..find(line, close) + close.len()],
+            close_color,
+            "\n",
+          ]);
+        } else {
+          rest = flatten(&[line, "\n"]);
+        }
+        let line = format!("    {} | {}", numb, rest);
+        text.push_str(&line);
+      }
+      text
+    }
+  }
+
+  // Matches anything.
+  const RE_ANY: &str = "(?s).*";
+
+  #[derive(Debug)]
+  struct MockState {
+    code: String,
+    index: usize,
+  }
+
+  prop_compose! {
+    fn state_tail()(
+      any in RE_ANY, ch in any::<char>()
+    ) -> MockState {
+      let code = format!("{}{}", ch, any);
+      let index = ch.len_utf8();
+      MockState { code, index }
+    }
+  }
+
+  proptest! {
+    #[test]
+    fn test_tail(state in state_tail()) {
+      let state_after = tail(State {
+        code: &state.code, index: 0
+      });
+      prop_assert_eq!(state.index, state_after.index);
+      prop_assert!(
+        state_after.index <= state.code.len(),
+        "\ncode length: {}\nindex: {}\n",
+        state.code.len(),
+        state_after.index
+      );
+    }
+  }
+
+  const COMMENT: &str = "//";
+  // Matches any line (i.e., that doesn't contain `'\r'` or `'\n'`).
+  const RE_LINE: &str = "[^\r\n]*";
+
+  prop_compose! {
+    fn state_skip_comment()(
+      line in RE_LINE.prop_filter(
+        "Values must not start with `COMMENT`.", |a| !a.starts_with(COMMENT)),
+      will_comment in any::<bool>(),
+      any in RE_ANY,
+    ) -> (MockState, bool) {
+      let index = if will_comment {
+        COMMENT.len() + line.len()
+      } else {
+        0
+      };
+      let code = if will_comment {
+        format!("{}{}\n{}", COMMENT, line, any)
+      } else {
+        format!("{}\n{}", line, any)
+      };
+      (MockState { code, index }, will_comment)
+    }
+  }
+
+  proptest! {
+    #[test]
+    fn test_skip_comment(state in state_skip_comment()) {
+      let answer = skip_comment(State {
+        code: &state.0.code, index: 0
+      }).unwrap();
+      let state_after = answer.0;
+      prop_assert_eq!(state.0.index, state_after.index);
+      prop_assert_eq!(state.1, answer.1);
+      prop_assert!(
+        state_after.index <= state.0.code.len(),
+        "\ncode length: {}\nindex: {}\n",
+        state.0.code.len(),
+        state_after.index
+      );
+    }
+  }
+
+  const RE_WHITESPACE: &str = "\\s+";
+
+  prop_compose! {
+    fn state_skip_spaces()(
+      any in RE_ANY.prop_filter(
+        "Values must not start with whitespace.", |a| a == a.trim_start()),
+      has_spaces in any::<bool>(),
+      spaces in RE_WHITESPACE,
+    ) -> (MockState, bool) {
+      let index = if has_spaces {
+        spaces.len()
+      } else {
+        0
+      };
+      let code = if has_spaces {
+        format!("{}{}", spaces, any)
+      } else {
+        any
+      };
+      (MockState { code, index }, has_spaces)
+    }
+  }
+
+  proptest! {
+    #[test]
+    fn test_skip_spaces(state in state_skip_spaces()) {
+      let answer = skip_spaces(State {
+        code: &state.0.code, index: 0
+      }).unwrap();
+      let state_after = answer.0;
+      prop_assert_eq!(state.0.index, state_after.index);
+      prop_assert_eq!(state.1, answer.1);
+      prop_assert!(
+        state_after.index <= state.0.code.len(),
+        "\ncode length: {}\nindex: {}\n",
+        state.0.code.len(),
+        state_after.index
+      );
+    }
+  }
+
+  prop_compose! {
+    fn state_skip()(
+      will_skip in any::<bool>(),
+      any in RE_ANY.prop_filter(
+        "Values must not start with whitespace or be a comment.", |a| {
+        let a_trimmed = a.trim_start();
+        !a_trimmed.starts_with(COMMENT) && a == a_trimmed
+      }),
+    )(
+      spaces_comments in if will_skip {
+        prop::collection::vec((RE_WHITESPACE, RE_LINE), 0..10)
+      } else {
+        prop::collection::vec(("", ""), 0)
+      },
+      will_skip in Just(will_skip),
+      any in Just(any),
+    ) -> (MockState, bool) {
+      let mut code: String = if will_skip {
+        spaces_comments
+          .iter()
+          .flat_map(|(space, comment)|
+            [space.as_str(), COMMENT, comment.as_str(), "\n"])
+          .collect()
+      } else {
+        String::with_capacity(any.len())
+      };
+      let index = code.len();
+      code.push_str(&any);
+      let will_skip = code.trim_start() != code || code.starts_with(COMMENT);
+      (MockState { code, index }, will_skip)
+    }
+  }
+
+  proptest! {
+    #[test]
+    fn test_skip(state in state_skip()) {
+      let answer = skip(State {
+        code: &state.0.code, index: 0
+      }).unwrap();
+      let state_after = answer.0;
+      prop_assert_eq!(state.0.index, state_after.index);
+      prop_assert_eq!(state.1, answer.1);
+      prop_assert!(
+        state_after.index <= state.0.code.len(),
+        "\ncode length: {}\nindex: {}\n",
+        state.0.code.len(),
+        state_after.index
+      );
+    }
+  }
+
+  prop_compose! {
+    fn range(from: usize, to: usize)(from in from..to)(
+      to in from..to,
+      from in Just(from)
+    ) -> (usize, usize) {
+      (from, to)
+    }
+  }
+
+  // Matches lines with at least a single character.
+  const RE_NON_EMPTY: &str = ".{1,}";
+
+  prop_compose! {
+    fn args_highlight()(code in RE_NON_EMPTY)(
+      code in Just(code.clone()),
+      (from, to) in range(0, code.len()).prop_filter(
+        "Values must be `char` boundaries.", move |(from, to)| {
+        code.is_char_boundary(*from) && code.is_char_boundary(*to)
+      })
+    ) -> (usize, usize, String) {
+      (from, to, code)
+    }
+  }
+
+  proptest! {
+    #[test]
+    fn test_highlight((from_index, to_index, code) in args_highlight()) {
+      prop_assert_eq!(
+        old_parser::highlight(from_index, to_index, &code),
+        highlight(from_index, to_index, &code)
+      );
+    }
+  }
 }


### PR DESCRIPTION
Ok so the major changes in this PR so far are:
* I removed some functions that seemed unused/unneeded:
  * `equal_at`, whose usages I replaced with `rest`.
  * `flatten`, which is just the `concat` method for slices.
  * `lines`, which was kinda bad anyway, as it unnecessarily allocated memory.
  * `head_default`, no longer needed due to changes to `skip_spaces`.
* `skip` no longer recurses, which should prevent that function from causing any stack overflows. It also mutates its argument now (not sure if that's bad, doesn't seem like it affects anything though).
* Similarly, the function signatures of `skip_comment` and `skip_spaces` now explicitly state that the argument is mutated (it seems like they were previously implicitly mutating their arguments anyway?).
* The `rest` method now doesn't directly index into a slice (which is dangerous and can cause panics), it instead calls `get` and returns an Option.
* `highlight` should allocate less memory now (only the allocation of the intermediate `String` should be occurring now, instead of also allocating a `Vec`).
* Added tests for a few of the functions (`tail`, the skipper functions, and `highlight`).