### PR TITLE
Two small changes in 'supperposed application'

### DIFF
--- a/HOW.md
+++ b/HOW.md
@@ -699,7 +699,7 @@ up in the function position of an application. For example, the situation below
 can happen at runtime:
 
 ```javascript
-({λx(x) λy(x)} 10)
+({λx(x) λy(y)} 10)
 ```
 
 This represents two superposed lambdas, applied to an argument `10`. If we
@@ -710,7 +710,7 @@ superposed application rule that deals with that situation:
 ```javascript
 ({a b} c)
 ----------------------- App-Sup
-{x0 x1} = c
+dup x0 x1 = c
 {(a x0) (b x1)}
 ```
 


### PR DESCRIPTION
I propose two changes in the Readme because these are subtly unexpected expressions that may be significant but go unexplained. So it is either a typo, or something more advanced that is not explained.

`({λx(x) λy(x)} 10)` -> `({λx(x) λy(y)} 10)` (There does not seem to be any use of the shared variable `x`, and variables cannot be shared anyway).`

The other one seems wrong, as the notation `{a b} = c` has never been introduced. Even if at this point it may make sense to replace `dup a b = c` by `{a b} = c`, a note about it would be welcome.

```
({a b} c)
----------------------- App-Sup
{x0 x1} = c --> dup x0 x1
{(a x0) (b x1)}
```