### PR TITLE
Better strings

### DIFF
--- a/src/builder.rs
+++ b/src/builder.rs
@@ -305,6 +305,13 @@ pub fn term_to_dynterm(comp: &rb::RuleBook, term: &lang::Term, free_vars: u64) -
         }
       }
       lang::Term::U32 { numb } => DynTerm::U32 { numb: *numb },
+      lang::Term::Str { stri } => {
+        let str_nil_ctr = comp.get_builtin_name("StrNil");
+        let str_cons_ctr = comp.get_builtin_name("StrCons");
+        stri.chars().rev().fold(DynTerm::Ctr { func: str_nil_ctr, args: vec![] }, |acc, char| {
+          DynTerm::Ctr { func: str_cons_ctr, args: vec![DynTerm::U32 { numb: char as u32 }, acc] }
+        })
+      }
       lang::Term::Op2 { oper, val0, val1 } => {
         let oper = convert_oper(oper);
         let val0 = Box::new(convert_term(val0, comp, depth + 0, vars));

--- a/src/rulebook.rs
+++ b/src/rulebook.rs
@@ -467,7 +467,7 @@ mod tests {
   use core::panic;
 
   use super::{gen_rulebook, sanitize_rule};
-  use crate::language::{read_file, read_rule};
+  use crate::{language::{read_file, read_rule}, rulebook::BUILTIN_NAMES};
 
   #[test]
   fn test_sanitize_expected_code() {
@@ -553,11 +553,11 @@ mod tests {
 
     // id_to_name e name_to_id testing
     // check expected length
-    assert_eq!(rulebook.id_to_name.len(), 3);
+    assert_eq!(rulebook.id_to_name.len(), BUILTIN_NAMES.len() + 3);
     // check determinism and existence
-    assert_eq!(rulebook.id_to_name.get(&0).unwrap(), "Double");
-    assert_eq!(rulebook.id_to_name.get(&1).unwrap(), "Zero");
-    assert_eq!(rulebook.id_to_name.get(&2).unwrap(), "Succ");
+    assert_eq!(rulebook.id_to_name.get(&(BUILTIN_NAMES.len() as u64 + 0)).unwrap(), "Double");
+    assert_eq!(rulebook.id_to_name.get(&(BUILTIN_NAMES.len() as u64 + 1)).unwrap(), "Zero");
+    assert_eq!(rulebook.id_to_name.get(&(BUILTIN_NAMES.len() as u64 + 2)).unwrap(), "Succ");
     // check cohesion
     let _size = rulebook.id_to_name.len();
     for (id, name) in rulebook.id_to_name {


### PR DESCRIPTION
Strings are now converted to linked lists at runtime, not compile time
This prevents stack overflows in files with long strings
Also readback strings as actual strings runtime.c