### PR TITLE
docs: always use -pthread instead of -lpthread

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ them up. Since it is recursive, HVM will parallelize it automatically.
 ```sh
 hvm r main 10                      # runs it with n=10
 hvm c main                         # compiles HVM to C
-clang -O2 main.c -o main -lpthread # compiles C to BIN
+clang -O2 main.c -o main -pthread  # compiles C to BIN
 ./main 30                          # runs it with n=30
 ```
 


### PR DESCRIPTION
As of gcc, `-pthread` defines some macros additionally that are crucial under some use cases, while `-lpthread` only tells the linker to link the pthread library. [Clang docs](https://clang.llvm.org/docs/ClangCommandLineReference.html#cmdoption-clang-pthread) also explicitly mentioned the `-pthread` argument.

Note that there are issues complaining about clang only uses `-pthread` during compile time but not link time which triggers an unused argument warning (see https://github.com/mesonbuild/meson/issues/2628), but on my machine with clang 14.0.6 I can't reproduce the warning.

See also: https://stackoverflow.com/a/23251828/8553479