### PR TITLE
Add no-std support.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,17 @@
 version = 3
 
 [[package]]
+name = "ahash"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fcb51a0695d8f838b1ee009b3fbf66bda078cd64590202a864a8f3e8c4315c47"
+dependencies = [
+ "getrandom",
+ "once_cell",
+ "version_check",
+]
+
+[[package]]
 name = "aho-corasick"
 version = "0.7.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -130,6 +141,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab5ef0d4909ef3724cc8cce6ccc8572c5c817592e9285f5464f8e86f8bd3726e"
 
 [[package]]
+name = "hashbrown"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
+dependencies = [
+ "ahash",
+]
+
+[[package]]
 name = "heck"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -146,15 +166,15 @@ dependencies = [
 
 [[package]]
 name = "highlight_error"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "809e18805660d7b6b2e2b9f316a5099521b5998d5cba4dda11b5157a21aaef03"
+version = "0.1.2"
+source = "git+https://github.com/FranchuFranchu/rust_highlight_error.git?branch=no-std#8a2ae2e51c27b7b90bc9aaac155796e8ca0aec33"
 
 [[package]]
 name = "hvm"
-version = "0.1.61"
+version = "0.1.64"
 dependencies = [
  "clap",
+ "hashbrown 0.12.3",
  "highlight_error",
  "itertools",
  "num_cpus",
@@ -169,7 +189,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0f647032dfaa1f8b6dc29bd3edb7bbef4861b8b8007ebb118d6db284fd59f6ee"
 dependencies = [
  "autocfg",
- "hashbrown",
+ "hashbrown 0.11.2",
 ]
 
 [[package]]
@@ -226,6 +246,12 @@ dependencies = [
  "hermit-abi",
  "libc",
 ]
+
+[[package]]
+name = "once_cell"
+version = "1.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "18a6dbe30758c9f83eb00cbea4ac95966305f5a7772f3f42ebfc7fc7eddbd8e1"
 
 [[package]]
 name = "os_str_bytes"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -171,7 +171,7 @@ source = "git+https://github.com/FranchuFranchu/rust_highlight_error.git?branch=
 
 [[package]]
 name = "hvm"
-version = "0.1.64"
+version = "0.1.65"
 dependencies = [
  "clap",
  "hashbrown 0.12.3",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,11 +18,22 @@ name = "hvm"
 test = false
 
 [dependencies]
-itertools = "0.10"
-num_cpus = "1.13"
-regex = "1.5.4"
-highlight_error = "0.1.1"
-clap = { version = "3.1.8", features = ["derive"] }
+itertools = { version = "0.10", optional = true }
+num_cpus = { version = "1.13", optional = true }
+regex = { version = "1.5.4",optional = true}
+highlight_error = { version = "0.1.2", default-features = false, git = "https://github.com/FranchuFranchu/rust_highlight_error.git", branch = "no-std"}
+clap = { version = "3.1.8", features = ["derive"], optional = true }
+hashbrown = "0.12.3"
+proptest = { version = "1.0", optional = true }
+
+[features]
+std = [
+	"dep:proptest", 
+	"dep:clap", 
+	"dep:regex",
+	"dep:num_cpus",
+	"itertools/use_std",
+]
+default = ["std"]
 
 [dev-dependencies]
-proptest = "1.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hvm"
-version = "0.1.64"
+version = "0.1.65"
 edition = "2021"
 description = "A lazy, beta-optimal, massively-parallel, non-garbage-collected and strongly-confluent functional compilation target."
 repository = "https://github.com/Kindelia/HVM"

--- a/src/api.rs
+++ b/src/api.rs
@@ -1,6 +1,8 @@
 #![allow(unused_variables)]
 #![allow(dead_code)]
 
+use alloc::{vec, string::ToString, string::String, boxed::Box};
+
 use crate::language as language;
 use crate::rulebook as rulebook;
 use crate::runtime as runtime;
@@ -127,6 +129,7 @@ impl Runtime {
   }
 
   /// Given a location, runs side-efefctive actions
+  #[cfg(feature = "std")]
   pub fn run_io(&mut self, host: u64) {
     runtime::run_io(&mut self.heap, &self.funs, host, Some(&self.book.id_to_name), false)
   }
@@ -163,6 +166,7 @@ impl Runtime {
 
 }
 
+#[cfg(feature = "std")] 
 pub fn example() -> Result<(), String> {
 
   let mut rt = crate::api::Runtime::from_code("

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,0 +1,62 @@
+use clap::{Parser, Subcommand};
+use crate::{compile_code, load_file_code, run_code};
+
+#[derive(Parser)]
+#[clap(author, version, about, long_about = None)]
+#[clap(propagate_version = true)]
+pub struct Cli {
+  #[clap(subcommand)]
+  pub command: Command,
+}
+
+#[derive(Subcommand)]
+pub enum Command {
+  #[clap(about = "Run a file interpreted", name = "run", aliases = &["r"])]
+  Run { file: String, params: Vec<String> },
+
+  #[clap(about = "Compile file to C",  name = "compile", aliases = &["c"])]
+  Compile {
+    file: String,
+    #[clap(long)]
+    single_thread: bool,
+  },
+
+  #[clap(about = "Run in debug mode", name = "debug", aliases = &["d"])]
+  Debug { file: String, params: Vec<String> },
+}
+
+
+pub(crate) fn run_cli() -> Result<(), String> {
+  let cli_matches = Cli::parse();
+
+  fn hvm(file: &str) -> String {
+    if file.ends_with(".hvm") {
+      file.to_string()
+    } else {
+      format!("{}.hvm", file)
+    }
+  }
+
+  match cli_matches.command {
+    Command::Compile { file, single_thread } => {
+      let file = &hvm(&file);
+      let code = load_file_code(file)?;
+
+      compile_code(&code, file, !single_thread)?;
+      Ok(())
+    }
+    Command::Run { file, params } => {
+      let code = load_file_code(&hvm(&file))?;
+
+      run_code(&code, false, params)?;
+      Ok(())
+    }
+
+    Command::Debug { file, params } => {
+      let code = load_file_code(&hvm(&file))?;
+
+      run_code(&code, true, params)?;
+      Ok(())
+    }
+  }
+}

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,4 +1,5 @@
 use clap::{Parser, Subcommand};
+
 use crate::{compile_code, load_file_code, run_code};
 
 #[derive(Parser)]

--- a/src/compiler.rs
+++ b/src/compiler.rs
@@ -1,15 +1,17 @@
 #![allow(clippy::identity_op)]
 
-use regex::Regex;
-use std::collections::HashMap;
-use std::io::Write;
+use hashbrown::HashMap;
 
 use crate::builder as bd;
 use crate::language as lang;
 use crate::rulebook as rb;
 use crate::runtime as rt;
 
+use alloc::{format, vec::Vec, string::ToString, string::String};
+
 pub fn compile_code_and_save(code: &str, file_name: &str, parallel: bool) -> Result<(), String> {
+  use std::io::Write;
+  
   let as_clang = compile_code(code, parallel)?;
   let mut file = std::fs::OpenOptions::new()
     .read(true)
@@ -491,7 +493,8 @@ fn c_runtime_template(
   arlen: u64,
   parallel: bool,
 ) -> String {
-  const C_RUNTIME_TEMPLATE: &str = include_str!("runtime.c");
+  use regex::Regex;
+  const C_RUNTIME_TEMPLATE: &str = core::include_str!("runtime.c");
   // Instantiate the template with the given sections' content
 
   const C_PARALLEL_FLAG_TAG: &str = "GENERATED_PARALLEL_FLAG";
@@ -510,7 +513,7 @@ fn c_runtime_template(
   let re = Regex::new(REPLACEMENT_TOKEN_PATTERN).unwrap();
 
   // Instantiate the template with the given sections' content
-
+  
   let result = re.replace_all(C_RUNTIME_TEMPLATE, |caps: &regex::Captures| {
     let tag = if let Some(cap1) = caps.get(1) {
       cap1.as_str()
@@ -526,7 +529,12 @@ fn c_runtime_template(
     };
 
     let parallel_flag = if parallel { "#define PARALLEL" } else { "" };
-    let num_threads = &num_cpus::get().to_string();
+    #[cfg(feature = "std")] let num_threads = {
+      &num_cpus::get().to_string()
+    };
+    #[cfg(not(feature = "std"))] let num_threads = {
+      "1"
+    };
     let nmlen = &nmlen.to_string();
     let arlen = &arlen.to_string();
     match tag {

--- a/src/compiler.rs
+++ b/src/compiler.rs
@@ -1,13 +1,13 @@
 #![allow(clippy::identity_op)]
 
+use alloc::{format, vec::Vec, string::String, string::ToString};
+
 use hashbrown::HashMap;
 
 use crate::builder as bd;
 use crate::language as lang;
 use crate::rulebook as rb;
 use crate::runtime as rt;
-
-use alloc::{format, vec::Vec, string::ToString, string::String};
 
 pub fn compile_code_and_save(code: &str, file_name: &str, parallel: bool) -> Result<(), String> {
   use std::io::Write;

--- a/src/language.rs
+++ b/src/language.rs
@@ -1,6 +1,7 @@
-use crate::{parser, builder::hash};
 use core::fmt;
-use alloc::{vec, format, vec::Vec, string::ToString, string::String, boxed::Box};
+use alloc::{boxed::Box, format, vec, vec::Vec, string::String, string::ToString};
+
+use crate::{parser, builder::hash};
 
 
 // Types

--- a/src/language.rs
+++ b/src/language.rs
@@ -1,6 +1,6 @@
-use crate::parser;
-use std::fmt;
-use std::hash::Hasher;
+use crate::{parser, builder::hash};
+use core::fmt;
+use alloc::{vec, format, vec::Vec, string::ToString, string::String, boxed::Box};
 
 
 // Types
@@ -125,7 +125,7 @@ impl fmt::Display for Term {
         if let Term::Ctr { name, args } = term {
           if name == "String.cons" && args.len() == 2 {
             if let Term::Num { numb } = *args[0] {
-              text.push(std::char::from_u32(numb as u32)?);
+              text.push(core::char::from_u32(numb as u32)?);
               go(&args[1], text)?;
             }
             return Some(());
@@ -383,11 +383,7 @@ pub fn parse_sym_sugar(state: parser::State) -> parser::Answer<Option<BTerm>> {
     Box::new(|state| {
       let (state, _)    = parser::text("%", state)?;
       let (state, name) = parser::name(state)?;
-      let hash = {
-        let mut hasher = std::collections::hash_map::DefaultHasher::new();
-        hasher.write(name.as_bytes());
-        hasher.finish()
-      };
+      let hash = hash(&name.as_bytes());
       Ok((state, Box::new(Term::Num { numb: hash })))
     }),
     state,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,5 @@
+#![cfg_attr(not(feature = "std"), no_std)]
+
 //! # High-order Virtual Machine (HVM) library
 //!
 //! Note: this API is **unstable**.
@@ -5,6 +7,7 @@
 // FIXME: what is the right way to export the definitions on api.rs as a lib?
 
 pub mod builder;
+#[cfg(feature = "std")]
 pub mod compiler;
 pub mod language;
 pub mod parser;
@@ -12,6 +15,10 @@ pub mod readback;
 pub mod rulebook;
 pub mod runtime;
 pub mod api;
+
+extern crate alloc;
+
+use alloc::string::{String, ToString};
 
 pub use builder::eval_code;
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,10 @@
+#![cfg_attr(not(feature = "std"), no_std)]
+
 mod api;
 mod builder;
+#[cfg(feature = "std")]
+mod cli;
+#[cfg(feature = "std")]
 mod compiler;
 mod language;
 mod parser;
@@ -7,74 +12,16 @@ mod readback;
 mod rulebook;
 mod runtime;
 
-use clap::{Parser, Subcommand};
-
-#[derive(Parser)]
-#[clap(author, version, about, long_about = None)]
-#[clap(propagate_version = true)]
-pub struct Cli {
-  #[clap(subcommand)]
-  pub command: Command,
-}
-
-#[derive(Subcommand)]
-pub enum Command {
-  #[clap(about = "Run a file interpreted", name = "run", aliases = &["r"])]
-  Run { file: String, params: Vec<String> },
-
-  #[clap(about = "Compile file to C",  name = "compile", aliases = &["c"])]
-  Compile {
-    file: String,
-    #[clap(long)]
-    single_thread: bool,
-  },
-
-  #[clap(about = "Run in debug mode", name = "debug", aliases = &["d"])]
-  Debug { file: String, params: Vec<String> },
-}
+extern crate alloc;
 
 fn main() {
-  match run_cli() {
+  #[cfg(feature = "std")]
+  match cli::run_cli() {
     Ok(..) => {}
     Err(err) => {
       eprintln!("{}", err);
     }
   };
-}
-
-fn run_cli() -> Result<(), String> {
-  let cli_matches = Cli::parse();
-
-  fn hvm(file: &str) -> String {
-    if file.ends_with(".hvm") {
-      file.to_string()
-    } else {
-      format!("{}.hvm", file)
-    }
-  }
-
-  match cli_matches.command {
-    Command::Compile { file, single_thread } => {
-      let file = &hvm(&file);
-      let code = load_file_code(file)?;
-
-      compile_code(&code, file, !single_thread)?;
-      Ok(())
-    }
-    Command::Run { file, params } => {
-      let code = load_file_code(&hvm(&file))?;
-
-      run_code(&code, false, params)?;
-      Ok(())
-    }
-
-    Command::Debug { file, params } => {
-      let code = load_file_code(&hvm(&file))?;
-
-      run_code(&code, true, params)?;
-      Ok(())
-    }
-  }
 }
 
 fn make_call(params: &Vec<String>) -> Result<language::Term, String> {
@@ -97,6 +44,7 @@ fn run_code(code: &str, debug: bool, params: Vec<String>) -> Result<(), String> 
   Ok(())
 }
 
+#[cfg(feature = "std")]
 fn compile_code(code: &str, name: &str, parallel: bool) -> Result<(), String> {
   if !name.ends_with(".hvm") {
     return Err("Input file must end with .hvm.".to_string());
@@ -111,6 +59,7 @@ fn load_file_code(file_name: &str) -> Result<String, String> {
   std::fs::read_to_string(file_name).map_err(|err| err.to_string())
 }
 
+#[cfg(feature = "std")]
 #[allow(dead_code)]
 fn run_example() -> Result<(), String> {
   // Source code

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -27,6 +27,8 @@
 
 #![allow(dead_code)]
 
+use alloc::{format, vec::Vec, string::ToString, string::String, boxed::Box};
+
 // Types
 // =====
 
@@ -497,6 +499,7 @@ pub fn testree_parser<'a>() -> Parser<'a, Box<Testree>> {
   })
 }
 
+#[cfg(feature = "std")]
 #[cfg(test)]
 mod tests {
   use super::*;

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -27,7 +27,7 @@
 
 #![allow(dead_code)]
 
-use alloc::{format, vec::Vec, string::ToString, string::String, boxed::Box};
+use alloc::{boxed::Box, format, vec::Vec, string::ToString, string::String, };
 
 // Types
 // =====

--- a/src/readback.rs
+++ b/src/readback.rs
@@ -3,11 +3,14 @@
 // FIXME: `as_code` and `as_term` should just call `readback`, but before doing so, we must test
 // the new readback properly to ensure it is correct
 
+
+use alloc::{vec, format, vec::Vec, string::ToString, string::String, boxed::Box};
+
+use hashbrown::{hash_map, HashMap, HashSet};
+
 use crate::language as lang;
 use crate::runtime as rt;
 use crate::runtime::{Ptr, Worker};
-use hashbrown::{hash_map, HashMap, HashSet};
-use alloc::{vec, format, vec::Vec, string::ToString, string::String, boxed::Box};
 
 /// Reads back a term from Runtime's memory
 pub fn as_code(mem: &Worker, i2n: Option<&HashMap<u64, String>>, host: u64) -> String {

--- a/src/readback.rs
+++ b/src/readback.rs
@@ -6,7 +6,8 @@
 use crate::language as lang;
 use crate::runtime as rt;
 use crate::runtime::{Ptr, Worker};
-use std::collections::{hash_map, HashMap, HashSet};
+use hashbrown::{hash_map, HashMap, HashSet};
+use alloc::{vec, format, vec::Vec, string::ToString, string::String, boxed::Box};
 
 /// Reads back a term from Runtime's memory
 pub fn as_code(mem: &Worker, i2n: Option<&HashMap<u64, String>>, host: u64) -> String {

--- a/src/rulebook.rs
+++ b/src/rulebook.rs
@@ -1,8 +1,9 @@
+use alloc::{boxed::Box, collections::BTreeMap, format, vec, vec::Vec, string::String, string::ToString, borrow::ToOwned};
+
+use hashbrown::{HashMap, HashSet};
+
 use crate::language as lang;
 use crate::runtime as rt;
-use alloc::collections::BTreeMap;
-use hashbrown::{HashMap, HashSet};
-use alloc::{vec, format, vec::Vec, string::ToString, string::String, boxed::Box, borrow::ToOwned};
 
 // RuleBook
 // ========

--- a/src/rulebook.rs
+++ b/src/rulebook.rs
@@ -1,6 +1,8 @@
 use crate::language as lang;
 use crate::runtime as rt;
-use std::collections::{BTreeMap, HashMap, HashSet};
+use alloc::collections::BTreeMap;
+use hashbrown::{HashMap, HashSet};
+use alloc::{vec, format, vec::Vec, string::ToString, string::String, boxed::Box, borrow::ToOwned};
 
 // RuleBook
 // ========
@@ -387,14 +389,14 @@ pub fn sanitize_rule(rule: &lang::Rule) -> Result<lang::Rule, String> {
       Some(x) => {
         match x.cmp(&1) {
           // if not used nothing is done
-          std::cmp::Ordering::Less => body,
+          core::cmp::Ordering::Less => body,
           // if used once just make a let then
-          std::cmp::Ordering::Equal => {
+          core::cmp::Ordering::Equal => {
             let term = lang::Term::Let { name: format!("{}.0", name), expr, body };
             Box::new(term)
           }
           // if used more then once duplicate
-          std::cmp::Ordering::Greater => {
+          core::cmp::Ordering::Greater => {
             let amount = amount.unwrap(); // certainly is not None
             let duplicated_times = amount - 1; // times that name is duplicated
             let aux_qtt = amount - 2; // quantity of aux variables
@@ -491,9 +493,14 @@ pub fn sanitize_rules(rules: &[lang::Rule]) -> Vec<lang::Rule> {
       match sanitize_rule(rule) {
         Ok(rule) => rule,
         Err(err) => {
-          println!("{}", err);
-          println!("On rule: `{}`.", rule);
-          std::process::exit(0); // FIXME: avoid this, propagate this error upwards
+          #[cfg(feature = "std")] {
+            println!("{}", err);
+            println!("On rule: `{}`.", rule);
+            std::process::exit(0); // FIXME: avoid this, propagate this error upwards
+          }
+          #[cfg(not(feature = "std"))] {
+            panic!("Error: {} \non rule: {}", err, rule)
+          }
         }
       }
     })

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -171,8 +171,9 @@
 #![allow(dead_code)]
 #![allow(non_snake_case)]
 
-use hashbrown::{hash_map, HashMap};
 use alloc::{vec, format, vec::Vec, string::ToString, string::String, boxed::Box};
+
+use hashbrown::{hash_map, HashMap};
 
 // Constants
 // ---------

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -171,7 +171,8 @@
 #![allow(dead_code)]
 #![allow(non_snake_case)]
 
-use std::collections::{hash_map, HashMap};
+use hashbrown::{hash_map, HashMap};
+use alloc::{vec, format, vec::Vec, string::ToString, string::String, boxed::Box};
 
 // Constants
 // ---------
@@ -383,7 +384,7 @@ pub fn ask_ari(mem: &Worker, lnk: Ptr) -> u64 {
   };
   // TODO: remove this in a future update where ari will be removed from the lnk
   if get_ari(lnk) != got {
-    println!("[WARNING] arity inconsistency");
+    #[cfg(feature = "std")] println!("[WARNING] arity inconsistency");
   }
   return got;
 }
@@ -560,7 +561,8 @@ pub fn reduce(
 
   loop {
     let term = ask_lnk(mem, host);
-
+    
+    #[cfg(feature = "std")] 
     if debug {
       println!("------------------------");
       println!("{}", show_term(mem, ask_lnk(mem, 0), _i2n, term));
@@ -923,6 +925,7 @@ pub fn normal(
   done
 }
 
+#[cfg(feature = "std")]
 pub fn run_io(
   mem: &mut Worker,
   funs: &Funs,
@@ -930,6 +933,7 @@ pub fn run_io(
   i2n: Option<&HashMap<u64, String>>,
   debug: bool,
 ) {
+  use std::io::{stdin, stdout, Write};
   fn read_input() -> String {
     let mut input = String::new();
     stdin().read_line(&mut input).expect("string");
@@ -937,7 +941,6 @@ pub fn run_io(
     if let Some('\r') = input.chars().next_back() { input.pop(); }
     return input;
   }
-  use std::io::{stdin,stdout,Write};
   loop {
     let term = reduce(mem, funs, host, i2n, debug);
     match get_tag(term) {
@@ -1019,7 +1022,7 @@ pub fn readback_string(mem: &mut Worker, funs: &Funs, host: u64) -> Option<Strin
           STRING_CONS => {
             let chr = reduce(mem, funs, get_loc(term, 0), None, false);
             if get_tag(chr) == NUM {
-              text.push(std::char::from_u32(get_num(chr) as u32).unwrap_or('?'));
+              text.push(core::char::from_u32(get_num(chr) as u32).unwrap_or('?'));
               host = get_loc(term, 1);
               continue;
             } else {
@@ -1041,6 +1044,7 @@ pub fn readback_string(mem: &mut Worker, funs: &Funs, host: u64) -> Option<Strin
 
 
 // Debug: prints call counts
+#[cfg(feature = "std")] 
 fn print_call_counts(i2n: Option<&HashMap<u64, String>>) {
   unsafe {
     let mut counts: Vec<(String, u64)> = Vec::new();


### PR DESCRIPTION
HVM only uses OS services for some things, including opening files and for the CLI program. Thus, a restricted subset of the HVM library can technically run without them. So I added a `std` feature, enabled by default, that compiles HVM to use the standard library. When it's disabled using `default-features = false` by a library that uses it, HVM will compile in `#![no_std]` mode, which prevents using the `std` library but allows running in embedded and kernel environments. 

I had to change some things to allow this. First of all, `regex` requires std, so the compiler to C is disabled in `no_std` mode. `std::collections::HashMap` was replaced by `hashbrown::HashMap` because std's requires the OS RNG. All imports from STD were changed with imports from `core` or `alloc`. Future commits should also do this to prevent new HVM versions from not compiling in `no_std`.

Performance should not be affected negatively. Hashbrown's benchmarks show that it's usually faster than std's hashmap.