### PR TITLE
Compiler: respect -M flag

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -34,7 +34,7 @@ fn run_cli() -> Result<(), String> {
       let file = &hvm(&file);
       let code = load_file_code(file)?;
 
-      compile_code(&code, file, !single_thread)?;
+      compile_code(&code, file, cli_matches.memory_size, !single_thread)?;
       Ok(())
     }
     Command::Run { file, params } => {
@@ -73,12 +73,12 @@ fn run_code(code: &str, debug: bool, params: Vec<String>, memory: usize) -> Resu
   Ok(())
 }
 
-fn compile_code(code: &str, name: &str, parallel: bool) -> Result<(), String> {
+fn compile_code(code: &str, name: &str, heap_size: usize, parallel: bool) -> Result<(), String> {
   if !name.ends_with(".hvm") {
     return Err("Input file must end with .hvm.".to_string());
   }
   let name = format!("{}.c", &name[0..name.len() - 4]);
-  compiler::compile_code_and_save(code, &name, parallel)?;
+  compiler::compile_code_and_save(code, &name, heap_size, parallel)?;
   println!("Compiled to '{}'.", name);
   Ok(())
 }
@@ -135,7 +135,7 @@ fn run_example() -> Result<(), String> {
   ";
 
   // Compiles to C and saves as 'main.c'
-  compiler::compile_code_and_save(code, "main.c", true)?;
+  compiler::compile_code_and_save(code, "main.c", 8589934592, true)?;
   println!("Compiled to 'main.c'.");
 
   // Evaluates with interpreter

--- a/src/runtime.c
+++ b/src/runtime.c
@@ -38,10 +38,9 @@ typedef pthread_t Thd;
 #define U64_PER_MB (0x20000)
 #define U64_PER_GB (0x8000000)
 
-// HVM pointers can address a 2^32 space of 64-bit elements, so, when the
-// program starts, we pre-alloc the maximum addressable heap, 32 GB. This will
-// be replaced by a proper arena allocator soon (see the Issues)!
-#define HEAP_SIZE (8 * U64_PER_GB * sizeof(u64))
+// When the program starts, we pre-alloc a big chunk of memory (set by cli flag).
+// This will be replaced by a proper arena allocator soon (see the Issues)!
+#define HEAP_SIZE /*! GENERATED_HEAP_SIZE */ 1 /* GENERATED_HEAP_SIZE !*/
 
 #ifdef PARALLEL
 #define MAX_WORKERS (/*! GENERATED_NUM_THREADS */ 1 /* GENERATED_NUM_THREADS !*/)


### PR DESCRIPTION
Previously, generated code allocated a hard-coded 8GiB heap, causing issues like https://github.com/Kindelia/HVM/issues/140 and https://github.com/Kindelia/HVM/issues/35.

This PR makes the heap size depend upon the compile-time flag `-M` (already used by `hvm r`).

As a side effect, this changes the default heap size for compiled programs to 4GiB (the default value of `-M` flag).