### PR TITLE
Replace generated CIDs with LOOKUP_CID macro

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -326,7 +326,7 @@ checksum = "c4a1e36c821dbe04574f602848a19f742f4fb3c98d40449f11bcad18d6b17421"
 
 [[package]]
 name = "hvm"
-version = "0.1.88"
+version = "0.1.89"
 dependencies = [
  "clap",
  "highlight_error",

--- a/src/compiler.rs
+++ b/src/compiler.rs
@@ -53,12 +53,12 @@ fn compile_book(comp: &rb::RuleBook, heap_size: usize, parallel: bool) -> String
       &format!("(strcmp(str,\"{}\")==0) ? {} : \\", name, comp.name_to_id.get(name).unwrap_or(&0)),
     );
 
-    line(&mut inits, 6, &format!("if (fun == LOOKUP_CID(\"{}\") ) {{", name));
+    line(&mut inits, 6, &format!("if (fun == lookup_cid(\"{}\") ) {{", name));
     inits.push_str(&init);
     line(&mut inits, 7, "break;");
     line(&mut inits, 6, "}");
 
-    line(&mut codes, 6, &format!("if (fun == LOOKUP_CID(\"{}\") ) {{", name));
+    line(&mut codes, 6, &format!("if (fun == lookup_cid(\"{}\") ) {{", name));
     codes.push_str(&code);
     line(&mut codes, 7, "break;");
     line(&mut codes, 6, "}");

--- a/src/runtime.c
+++ b/src/runtime.c
@@ -4,6 +4,7 @@
 
 #include <assert.h>
 #include <stdint.h>
+#include <stdbool.h>
 #include <inttypes.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -109,13 +110,10 @@ typedef u64 Ptr;
 #define GTN (0xE)
 #define NEQ (0xF)
 
-//GENERATED_CONSTRUCTOR_IDS_START//
-/*! GENERATED_CONSTRUCTOR_IDS !*/
-//GENERATED_CONSTRUCTOR_IDS_END//
 
-#ifndef _MAIN_
-#define _MAIN_ (0)
-#endif
+#define LOOKUP_CID(str) (\
+/*! GENERATED_CONSTRUCTOR_IDS !*/\
+-1)
 
 // Threads
 // -------
@@ -538,11 +536,8 @@ Ptr reduce(Worker* mem, u64 root, u64 slen) {
           u64 fun = get_ext(term);
           u64 ari = ask_ari(mem, term);
 
-          switch (fun)
           //GENERATED_REWRITE_RULES_STEP_0_START//
-          {
 /*! GENERATED_REWRITE_RULES_STEP_0 !*/
-          }
           //GENERATED_REWRITE_RULES_STEP_0_END//
 
           break;
@@ -841,11 +836,8 @@ Ptr reduce(Worker* mem, u64 root, u64 slen) {
           u64 fun = get_ext(term);
           u64 ari = ask_ari(mem, term);
 
-          switch (fun)
           //GENERATED_REWRITE_RULES_STEP_1_START//
-          {
 /*! GENERATED_REWRITE_RULES_STEP_1 !*/
-          }
           //GENERATED_REWRITE_RULES_STEP_1_END//
 
           break;
@@ -1421,9 +1413,9 @@ int main(int argc, char* argv[]) {
   mem.funs = id_to_arity_size;
   assert(mem.node);
   if (argc <= 1) {
-    mem.node[mem.size++] = Cal(0, _MAIN_, 0);
+    mem.node[mem.size++] = Cal(0, LOOKUP_CID("Main"), 0);
   } else {
-    mem.node[mem.size++] = Cal(argc - 1, _MAIN_, 1);
+    mem.node[mem.size++] = Cal(argc - 1, LOOKUP_CID("Main"), 1);
     for (u64 i = 1; i < argc; ++i) {
       mem.node[mem.size++] = parse_arg(argv[i], id_to_name_data, id_to_name_size);
     }

--- a/src/runtime.c
+++ b/src/runtime.c
@@ -111,9 +111,13 @@ typedef u64 Ptr;
 #define NEQ (0xF)
 
 
-#define LOOKUP_CID(str) (\
-/*! GENERATED_CONSTRUCTOR_IDS !*/\
--1)
+#define FORCE_INLINE __attribute__((always_inline)) inline
+
+FORCE_INLINE u64 lookup_cid(const char* str) {
+  return
+    /*! GENERATED_CONSTRUCTOR_IDS !*/
+    -1;
+}
 
 // Threads
 // -------
@@ -1413,9 +1417,9 @@ int main(int argc, char* argv[]) {
   mem.funs = id_to_arity_size;
   assert(mem.node);
   if (argc <= 1) {
-    mem.node[mem.size++] = Cal(0, LOOKUP_CID("Main"), 0);
+    mem.node[mem.size++] = Cal(0, lookup_cid("Main"), 0);
   } else {
-    mem.node[mem.size++] = Cal(argc - 1, LOOKUP_CID("Main"), 1);
+    mem.node[mem.size++] = Cal(argc - 1, lookup_cid("Main"), 1);
     for (u64 i = 1; i < argc; ++i) {
       mem.node[mem.size++] = parse_arg(argv[i], id_to_name_data, id_to_name_size);
     }


### PR DESCRIPTION
# The problem

Currently, the compiler backed generates a C macro for each function name, e.g.

```c

//GENERATED_CONSTRUCTOR_IDS_START//
#define _GEN_ (31)
#define _SUM_ (28)
#define _MAIN_ (32)

//GENERATED_CONSTRUCTOR_IDS_END//
```
These macros are then used in generated case splits, e.g.
```c
         switch (fun)
          //GENERATED_REWRITE_RULES_STEP_0_START//
          {
            case _GEN_: { //<snip>
            };
            case _SUM_: { //<snip>
            };
            case _MAIN_: {//<snip>
            };

```

This causes the following issues:

* Encoding names with special characters (e.g. `IO.put_char`) requires [hard-to-get-right escaping code](https://github.com/Kindelia/HVM/blob/0bcbae286f995bc14895b0774914b1e19cf5e34e/src/compiler.rs#L32-L39) in the HVM compiler
* Downstream users of HVM may need to [re-implement this escaping code](https://github.com/lawcho/rpphp/blob/14ed49dc2e1f7a7de5e53a8c3f10107a1bfcd8da/platgen.hs#L63-L68)
* Even if the escaping is clash-free, the macro names can still clash with macros from libraries

# A solution

This PR fixes the issues above by replacing the family of `_COMPILED_NAME_` macros with a single `LOOKUP_CID` function macro, e.g.

```c
#define LOOKUP_CID(str) (\
(strcmp(str,"Gen")==0) ? 28 : \
(strcmp(str,"Main")==0) ? 32 : \
(strcmp(str,"Sum")==0) ? 31 : \
\
-1)
```
This macro is used similarly to before:
```c
          //GENERATED_REWRITE_RULES_STEP_0_START//
            if (fun == LOOKUP_CID("Gen") ) { //<snip>
              break;
            }
            if (fun == LOOKUP_CID("Main") ) { //<snip>
              break;
            }
            if (fun == LOOKUP_CID("Sum") ) { //<snip>
              break;
            }
```

# Benchmarks

In theory, this change increases the complexity of constructor-comparison from `O(1)` to `O(# constructors)`.
In practice, I did not see a noticeable slowdown on the test suite.

I think this is because the C optimizer evaluates `LOOKUP_CID(str)` fully at compile-time, when `str` is constant.

## Timings before this PR
```bash
time python3 tests/test_cli.py --run-mode compiled --hvm-cmd="hvm" >/dev/null

real    0m6,260s
user    0m4,669s
sys     0m1,645s
```
## Timings after this PR
```bash
$ time python3 tests/test_cli.py --run-mode compiled --hvm-cmd="./target/debug/hvm" >/dev/null

real    0m7,367s
user    0m5,424s
sys     0m1,613s
