### PR TITLE
Make state changes in reducer more comprehensible

### DIFF
--- a/bench/benchmark.js
+++ b/bench/benchmark.js
@@ -41,7 +41,7 @@ var langs = {
       exec("cd main; cargo build --release; mv target/release/main ../main.bin");
     },
     bench: (task, size, tids) => {
-      return bench('./main.bin run -t '+tids+' "(Main ' + size + ')" 2>/dev/null');
+      return bench('./main.bin run -t '+tids+' "(Main ' + size + ')"');
     },
     clean: () => {
       exec("rm main.hvm");

--- a/flake.lock
+++ b/flake.lock
@@ -88,11 +88,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1668243825,
-        "narHash": "sha256-EjgLCV5fI20dVVbpB5Gy+UV5LF2EZXwRTCuIyn3s7AM=",
+        "lastModified": 1668466876,
+        "narHash": "sha256-hqOrw28G4ipvZIq7EAlTvRvb/p53Fi4IpgFmt8WQGFI=",
         "owner": "nix-community",
         "repo": "dream2nix",
-        "rev": "86d6c6a42e1436664a04490491414adf2c2e08be",
+        "rev": "b2cd899b0f579ff83d8e98eb5a21d9602a1cd2c7",
         "type": "github"
       },
       "original": {
@@ -104,11 +104,11 @@
     "flake-compat": {
       "flake": false,
       "locked": {
-        "lastModified": 1648199409,
-        "narHash": "sha256-JwPKdC2PoVBkG6E+eWw3j6BMR6sL3COpYWfif7RVb8Y=",
+        "lastModified": 1650374568,
+        "narHash": "sha256-Z+s0J8/r907g149rllvwhb4pKi8Wam5ij0st8PwAh+E=",
         "owner": "edolstra",
         "repo": "flake-compat",
-        "rev": "64a525ee38886ab9028e6f61790de0832aa3ef03",
+        "rev": "b4a34015c698c7793d592d66adbab377907a2be8",
         "type": "github"
       },
       "original": {
@@ -143,27 +143,41 @@
         "rust-overlay": "rust-overlay"
       },
       "locked": {
-        "lastModified": 1668390517,
-        "narHash": "sha256-AyLXLqFhqnAqxobdsVrz6ss8oWn7lN8JTZKfyAwOOto=",
+        "lastModified": 1668492775,
+        "narHash": "sha256-m+HWoMCvc1MaBiQ4dQ5YmoT1/dstFHYUe1bQ/L+a4MA=",
         "owner": "yusdacra",
         "repo": "nix-cargo-integration",
-        "rev": "774b49912e6ae219e20bbb39258f8a283f6a251c",
+        "rev": "002e6ca5df976e8d0e582e1826f7b85a5c4dcea8",
         "type": "github"
       },
       "original": {
         "owner": "yusdacra",
         "repo": "nix-cargo-integration",
-        "rev": "774b49912e6ae219e20bbb39258f8a283f6a251c",
+        "type": "github"
+      }
+    },
+    "nix-filter": {
+      "locked": {
+        "lastModified": 1666547822,
+        "narHash": "sha256-razwnAybPHyoAyhkKCwXdxihIqJi1G6e1XP4FQOJTEs=",
+        "owner": "numtide",
+        "repo": "nix-filter",
+        "rev": "1a3b735e13e90a8d2fd5629f2f8363bd7ffbbec7",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "nix-filter",
         "type": "github"
       }
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1668087632,
-        "narHash": "sha256-T/cUx44aYDuLMFfaiVpMdTjL4kpG7bh0VkN6JEM78/E=",
+        "lastModified": 1668417584,
+        "narHash": "sha256-yeuEyxKPwsm5fIHN49L/syn9g5coxnPp3GsVquhrv5A=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "5f588eb4a958f1a526ed8da02d6ea1bea0047b9f",
+        "rev": "013fcdd106823416918004bb684c3c186d3c460f",
         "type": "github"
       },
       "original": {
@@ -177,17 +191,18 @@
       "inputs": {
         "flake-compat": "flake-compat",
         "nci": "nci",
+        "nix-filter": "nix-filter",
         "nixpkgs": "nixpkgs"
       }
     },
     "rust-overlay": {
       "flake": false,
       "locked": {
-        "lastModified": 1668307432,
-        "narHash": "sha256-UUEsHnKvlnrSFdDwnlacPojFZg+75wOxCGngGmEEeTw=",
+        "lastModified": 1668479979,
+        "narHash": "sha256-UI+JUCBaMpn+5Y1hSePmndbYX5zu0+bavlfzrhPrGEk=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "3a7faa4395868f3a183b49cf9090624e3361b541",
+        "rev": "2342f70f7257046effc031333c4cfdea66c91d82",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -7,12 +7,15 @@
     };
     nci = {
       inputs.nixpkgs.follows = "nixpkgs";
-      # The next commit, 5d3d4b15b7a5f2f393fe60fcdc32deeaab88d704, is broken.
-      url = "github:yusdacra/nix-cargo-integration/774b49912e6ae219e20bbb39258f8a283f6a251c";
+      url = "github:yusdacra/nix-cargo-integration";
     };
+    nix-filter.url = "github:numtide/nix-filter";
     nixpkgs.url = "github:nixos/nixpkgs/nixos-unstable";
   };
-  outputs = inputs:
+  outputs = inputs: let
+    nix-filter = import inputs.nix-filter;
+    pkgs = common: packages: builtins.map (element: common.pkgs.${element}) packages;
+  in
     inputs.nci.lib.makeOutputs {
       config = common: {
         cCompiler = {
@@ -25,11 +28,11 @@
             package = "hvm";
           };
         };
-        runtimeLibs = [common.pkgs.openssl];
+        runtimeLibs = pkgs common ["openssl"];
         shell = {commands = builtins.map (element: {package = common.pkgs.${element};}) ["ghc" "nodejs"];};
       };
       pkgConfig = common: let
-        override = {buildInputs = [common.pkgs.openssl common.pkgs.pkg-config];};
+        override = {buildInputs = pkgs common ["openssl" "pkg-config"];};
       in {
         hvm = {
           app = true;
@@ -43,7 +46,15 @@
           };
         };
       };
-      # Exclude "wasm" directory because it causes "error: attribute 'crane' missing" and "error: expected a derivation".
-      root = builtins.filterSource (path: type: !(type == "directory" && baseNameOf path == "wasm")) ./.;
+      # Only include directories necessary for building the project, to make the derivation smaller.
+      root = nix-filter {
+        root = ./.;
+        include = [
+          ./src
+          ./Cargo.lock
+          ./Cargo.toml
+          ./rust-toolchain.toml
+        ];
+      };
     };
 }

--- a/src/compiler/compile.rs
+++ b/src/compiler/compile.rs
@@ -56,7 +56,7 @@ pub fn build_rulebook(book: &language::rulebook::RuleBook) -> (String, String) {
     if id >= &runtime::PRECOMP_COUNT {
       let name = book.id_to_name.get(id).unwrap();
       if let Some(rules) = book.rule_group.get(name) {
-        let (visit_fn, apply_fn) = build_function(book, &name, &rules.1);
+        let (visit_fn, apply_fn) = build_function(book, name, &rules.1);
         line(&mut precomp_fns, 0, &format!("{}", visit_fn));
         line(&mut precomp_fns, 0, &format!("{}", apply_fn));
       }
@@ -65,46 +65,46 @@ pub fn build_rulebook(book: &language::rulebook::RuleBook) -> (String, String) {
 
   // fast visit
   let mut fast_visit = String::new();
-  line(&mut fast_visit, 7, &format!("match fid {{"));
+  line(&mut fast_visit, 6, &format!("match fid {{"));
   for id in itertools::sorted(book.id_to_arit.keys()) {
     if id >= &runtime::PRECOMP_COUNT {
       let name = book.id_to_name.get(id).unwrap();
       if let Some(rules) = book.rule_group.get(name) {
-        let (visit_fun, apply_fun) = build_function(book, &name, &rules.1);
-        line(&mut fast_visit, 8, &format!("{} => {{", &build_name(&name)));
-        line(&mut fast_visit, 9, &format!("if {}_visit(ReduceCtx {{ heap, prog, tid, term, visit, redex, cont: &mut cont, host: &mut host }}) {{", &build_name(&name)));
-        line(&mut fast_visit, 10, &format!("continue 'visit;"));
-        line(&mut fast_visit, 9, &format!("}} else {{"));
-        line(&mut fast_visit, 10, &format!("break 'visit;"));
-        line(&mut fast_visit, 9, &format!("}}"));
+        let (visit_fun, apply_fun) = build_function(book, name, &rules.1);
+        line(&mut fast_visit, 7, &format!("{} => {{", &build_name(name)));
+        line(&mut fast_visit, 8, &format!("if {}_visit(ReduceCtx {{ heap, prog, tid, term, visit, redex, cont: &mut cont, host: &mut host }}) {{", &build_name(name)));
+        line(&mut fast_visit, 9, &format!("goto!(Visit);"));
+        line(&mut fast_visit, 8, &format!("}} else {{"));
+        line(&mut fast_visit, 9, &format!("goto!(Apply);"));
         line(&mut fast_visit, 8, &format!("}}"));
+        line(&mut fast_visit, 7, &format!("}}"));
       };
     }
   }
-  line(&mut fast_visit, 8, &format!("_ => {{}}"));
-  line(&mut fast_visit, 7, &format!("}}"));
+  line(&mut fast_visit, 7, &format!("_ => {{}}"));
+  line(&mut fast_visit, 6, &format!("}}"));
 
   // fast apply
   let mut fast_apply = String::new();
-  line(&mut fast_apply, 8, &format!("match fid {{"));
+  line(&mut fast_apply, 6, &format!("match fid {{"));
   for id in itertools::sorted(book.id_to_arit.keys()) {
     if id >= &runtime::PRECOMP_COUNT {
       let name = book.id_to_name.get(id).unwrap();
       let rules = 
       if let Some(rules) = book.rule_group.get(name) {
-        let (visit_fun, apply_fun) = build_function(book, &name, &rules.1);
-        line(&mut fast_apply, 9, &format!("{} => {{", &build_name(&name)));
-        line(&mut fast_apply, 10, &format!("if {}_apply(ReduceCtx {{ heap, prog, tid, term, visit, redex, cont: &mut cont, host: &mut host }}) {{", &build_name(&name)));
-        line(&mut fast_apply, 11, &format!("continue 'work;"));
-        line(&mut fast_apply, 10, &format!("}} else {{"));
-        line(&mut fast_apply, 11, &format!("break 'apply;"));
-        line(&mut fast_apply, 10, &format!("}}"));
-        line(&mut fast_apply, 9, &format!("}}"));
+        let (visit_fun, apply_fun) = build_function(book, name, &rules.1);
+        line(&mut fast_apply, 7, &format!("{} => {{", &build_name(name)));
+        line(&mut fast_apply, 8, &format!("if {}_apply(ReduceCtx {{ heap, prog, tid, term, visit, redex, cont: &mut cont, host: &mut host }}) {{", &build_name(name)));
+        line(&mut fast_apply, 9, &format!("goto!(Visit);"));
+        line(&mut fast_apply, 8, &format!("}} else {{"));
+        line(&mut fast_apply, 9, &format!("goto!(Call);"));
+        line(&mut fast_apply, 8, &format!("}}"));
+        line(&mut fast_apply, 7, &format!("}}"));
       };
     }
   }
-  line(&mut fast_apply, 9, &format!("_ => {{}}"));
-  line(&mut fast_apply, 8, &format!("}}"));
+  line(&mut fast_apply, 7, &format!("_ => {{}}"));
+  line(&mut fast_apply, 6, &format!("}}"));
 
   // precomp.rs
   let precomp_rs : &str = include_str!("./../runtime/base/precomp.rs");
@@ -117,7 +117,7 @@ pub fn build_rulebook(book: &language::rulebook::RuleBook) -> (String, String) {
   let reducer_rs = reducer_rs.replace("//[[CODEGEN:FAST-VISIT]]//\n", &fast_visit);
   let reducer_rs = reducer_rs.replace("//[[CODEGEN:FAST-APPLY]]//\n", &fast_apply);
 
-  return (precomp_rs, reducer_rs);
+  (precomp_rs, reducer_rs)
 }
 
 pub fn build_function(

--- a/src/runtime/base/reducer.rs
+++ b/src/runtime/base/reducer.rs
@@ -49,6 +49,7 @@ pub fn reduce(heap: &Heap, prog: &Program, tids: &[usize], root: u64, debug: boo
 }
 
 pub fn reducer(heap: &Heap, prog: &Program, tids: &[usize], stop: &AtomicBool, root: u64, tid: usize, debug: bool) {
+  enum State { Init, Visit, Call, Apply, Blink, Steal }
 
   let debug_print = |term: Ptr| {
     println!("{}\n----------------", show_term(heap, prog, load_ptr(heap, root), term));
@@ -67,197 +68,204 @@ pub fn reducer(heap: &Heap, prog: &Program, tids: &[usize], stop: &AtomicBool, r
   } else {
     (0, u64::MAX)
   };
+  let mut state = State::Init;
 
   // State Machine
   'main: loop {
-    'init: {
-      if host == u64::MAX {
-        break 'init;
+    macro_rules! goto {
+      ($variant:ident) => {
+        state = State::$variant;
+        continue 'main;
+      };
+    }
+
+    match state {
+      State::Init => {
+        if host == u64::MAX {
+          goto!(Steal);
+        } else {
+          goto!(Visit);
+        }
       }
-      //println!("main {} {}", show_ptr(load_ptr(heap, host)), show_term(heap, prog, load_ptr(heap, host), host));
-      'work: loop {
+      State::Visit => {
         //println!("work {} {}", show_ptr(load_ptr(heap, host)), show_term(heap, prog, load_ptr(heap, host), host));
-        'visit: loop {
-          let term = load_ptr(heap, host);
-          if debug { debug_print(term); }
-          match get_tag(term) {
-            APP => {
-              if app::visit(ReduceCtx { heap, prog, tid, term, visit, redex, cont: &mut cont, host: &mut host }) {
-                continue 'visit;
-              } else {
-                break 'work;
-              }
+        let term = load_ptr(heap, host);
+        if debug { debug_print(term); }
+        match get_tag(term) {
+          APP => {
+            if app::visit(ReduceCtx { heap, prog, tid, term, visit, redex, cont: &mut cont, host: &mut host }) {
+              goto!(Visit);
+            } else {
+              goto!(Blink);
             }
-            DP0 | DP1 => {
-              match acquire_lock(heap, tid, term) {
-                Err(locker_tid) => {
-                  delay.push(new_visit(host, cont));
-                  break 'work;
-                }
-                Ok(_) => {
-                  // If the term changed, release lock and try again
-                  if term != load_ptr(heap, host) {
-                    release_lock(heap, tid, term);
-                    continue 'visit;
-                  } else {
-                    if dup::visit(ReduceCtx { heap, prog, tid, term, visit, redex, cont: &mut cont, host: &mut host }) {
-                      continue 'visit;
-                    } else {
-                      break 'work;
-                    }
-                  }
+          }
+          DP0 | DP1 => {
+            match acquire_lock(heap, tid, term) {
+              Err(_locker_tid) => {
+                delay.push(new_visit(host, cont));
+                goto!(Blink);
+              }
+              Ok(_) => {
+                // If the term changed, release lock and try again
+                if term != load_ptr(heap, host) {
+                  release_lock(heap, tid, term);
+                  goto!(Visit);
+                } else if dup::visit(ReduceCtx { heap, prog, tid, term, visit, redex, cont: &mut cont, host: &mut host }) {
+                  goto!(Visit);
+                } else {
+                  goto!(Blink);
                 }
               }
             }
-            OP2 => {
-              if op2::visit(ReduceCtx { heap, prog, tid, term, visit, redex, cont: &mut cont, host: &mut host }) {
-                continue 'visit;
-              } else {
-                break 'work;
-              }
+          }
+          OP2 => {
+            if op2::visit(ReduceCtx { heap, prog, tid, term, visit, redex, cont: &mut cont, host: &mut host }) {
+              goto!(Visit);
+            } else {
+              goto!(Blink);
             }
-            FUN => {
-              let fid = get_ext(term);
+          }
+          FUN => {
+            let fid = get_ext(term);
 //[[CODEGEN:FAST-VISIT]]//
-              match &prog.funs.get(&fid) {
-                Some(Function::Interpreted { arity: fn_arity, visit: fn_visit, apply: fn_apply }) => {
-                  if fun::visit(ReduceCtx { heap, prog, tid, term, visit, redex, cont: &mut cont, host: &mut host }, &fn_visit.strict_idx) {
-                    continue 'visit;
-                  } else {
-                    break 'visit;
-                  }
-                }
-                Some(Function::Compiled { arity: fn_arity, visit: fn_visit, apply: fn_apply }) => {
-                  if fn_visit(ReduceCtx { heap, prog, tid, term, visit, redex, cont: &mut cont, host: &mut host }) {
-                    continue 'visit;
-                  } else {
-                    break 'visit;
-                  }
-                }
-                None => {
-                  break 'visit;
-                }
-              }
-            }
-            _ => {
-              break 'visit;
-            }
-          }
-        }
-        'call: loop {
-          'apply: loop {
-            //println!("apply {} {}", show_ptr(load_ptr(heap, host)), show_term(heap, prog, load_ptr(heap, host), host));
-            let term = load_ptr(heap, host);
-            if debug { debug_print(term); }
-            // Apply rewrite rules
-            match get_tag(term) {
-              APP => {
-                if app::apply(ReduceCtx { heap, prog, tid, term, visit, redex, cont: &mut cont, host: &mut host }) {
-                  continue 'work;
+            match &prog.funs.get(&fid) {
+              Some(Function::Interpreted { arity: fn_arity, visit: fn_visit, apply: fn_apply }) => {
+                if fun::visit(ReduceCtx { heap, prog, tid, term, visit, redex, cont: &mut cont, host: &mut host }, &fn_visit.strict_idx) {
+                  goto!(Visit);
                 } else {
-                  break 'apply;
+                  goto!(Apply);
                 }
               }
-              DP0 | DP1 => {
-                if dup::apply(ReduceCtx { heap, prog, tid, term, visit, redex, cont: &mut cont, host: &mut host }) {
-                  release_lock(heap, tid, term);
-                  continue 'work;
+              Some(Function::Compiled { arity: fn_arity, visit: fn_visit, apply: fn_apply }) => {
+                if fn_visit(ReduceCtx { heap, prog, tid, term, visit, redex, cont: &mut cont, host: &mut host }) {
+                  goto!(Visit);
                 } else {
-                  release_lock(heap, tid, term);
-                  break 'apply;
+                  goto!(Apply);
                 }
               }
-              OP2 => {
-                if op2::apply(ReduceCtx { heap, prog, tid, term, visit, redex, cont: &mut cont, host: &mut host }) {
-                  continue 'work;
-                } else {
-                  break 'apply;
-                }
-              }
-              FUN => {
-                let fid = get_ext(term);
-//[[CODEGEN:FAST-APPLY]]//
-                match &prog.funs.get(&fid) {
-                  Some(Function::Interpreted { arity: fn_arity, visit: fn_visit, apply: fn_apply }) => {
-                    if fun::apply(ReduceCtx { heap, prog, tid, term, visit, redex, cont: &mut cont, host: &mut host }, fid, *fn_arity, fn_visit, fn_apply) {
-                      continue 'work;
-                    } else {
-                      break 'apply;
-                    }
-                  }
-                  Some(Function::Compiled { arity: fn_arity, visit: fn_visit, apply: fn_apply }) => {
-                    if fn_apply(ReduceCtx { heap, prog, tid, term, visit, redex, cont: &mut cont, host: &mut host }) {
-                      continue 'work;
-                    } else {
-                      break 'apply;
-                    }
-                  }
-                  None => {
-                    break 'apply;
-                  }
-                }
-              }
-              _ => {
-                break 'apply;
+              None => {
+                goto!(Apply);
               }
             }
           }
-          // If root is on WHNF, halt
-          if cont == REDEX_CONT_RET {
-            stop.store(true, Ordering::Relaxed);
-            break 'main;
-          }
-          // Otherwise, try reducing the parent redex
-          else if let Some((new_cont, new_host)) = redex.complete(cont) {
-            cont = new_cont;
-            host = new_host;
-            continue 'call;
-          }
-          // Otherwise, visit next pointer
-          else {
-            break 'work;
+          _ => {
+            goto!(Apply);
           }
         }
       }
-      'blink: loop {
+      State::Apply => {
+        //println!("apply {} {}", show_ptr(load_ptr(heap, host)), show_term(heap, prog, load_ptr(heap, host), host));
+        let term = load_ptr(heap, host);
+        if debug { debug_print(term); }
+        // Apply rewrite rules
+        match get_tag(term) {
+          APP => {
+            if app::apply(ReduceCtx { heap, prog, tid, term, visit, redex, cont: &mut cont, host: &mut host }) {
+              goto!(Visit);
+            } else {
+              goto!(Call);
+            }
+          }
+          DP0 | DP1 => {
+            if dup::apply(ReduceCtx { heap, prog, tid, term, visit, redex, cont: &mut cont, host: &mut host }) {
+              release_lock(heap, tid, term);
+              goto!(Visit);
+            } else {
+              release_lock(heap, tid, term);
+              goto!(Call);
+            }
+          }
+          OP2 => {
+            if op2::apply(ReduceCtx { heap, prog, tid, term, visit, redex, cont: &mut cont, host: &mut host }) {
+              goto!(Visit);
+            } else {
+              goto!(Call);
+            }
+          }
+          FUN => {
+            let fid = get_ext(term);
+//[[CODEGEN:FAST-APPLY]]//
+            match &prog.funs.get(&fid) {
+              Some(Function::Interpreted { arity: fn_arity, visit: fn_visit, apply: fn_apply }) => {
+                if fun::apply(ReduceCtx { heap, prog, tid, term, visit, redex, cont: &mut cont, host: &mut host }, fid, *fn_arity, fn_visit, fn_apply) {
+                  goto!(Visit);
+                } else {
+                  goto!(Call);
+                }
+              }
+              Some(Function::Compiled { arity: fn_arity, visit: fn_visit, apply: fn_apply }) => {
+                if fn_apply(ReduceCtx { heap, prog, tid, term, visit, redex, cont: &mut cont, host: &mut host }) {
+                  goto!(Visit);
+                } else {
+                  goto!(Call);
+                }
+              }
+              None => {
+                goto!(Call);
+              }
+            }
+          }
+          _ => {
+            goto!(Call);
+          }
+        }
+      }
+      State::Call => {
+        // If root is on WHNF, halt
+        if cont == REDEX_CONT_RET {
+          stop.store(true, Ordering::Relaxed);
+          break 'main;
+        }
+        // Otherwise, try reducing the parent redex
+        else if let Some((new_cont, new_host)) = redex.complete(cont) {
+          cont = new_cont;
+          host = new_host;
+          goto!(Apply);
+        }
+        // Otherwise, visit next pointer
+        else {
+          goto!(Blink);
+        }
+      }
+      State::Blink => {
         // If available, visit a new location
         if let Some((new_cont, new_host)) = visit.pop() {
           cont = new_cont;
           host = new_host;
-          continue 'main;
+          goto!(Init);
         }
         // If available, visit a delayed location
-        else if delay.len() > 0 {
+        else if !delay.is_empty() {
           for next in delay.drain(0..).rev() {
             visit.push(next);
           }
-          continue 'blink;
+          goto!(Blink);
         }
         // Otherwise, we have nothing to do
         else {
-          break 'blink;
+          goto!(Init);
         }
       }
-    }
-    'steal: loop {
-      //println!("[{}] steal", tid);
-      if stop.load(Ordering::Relaxed) {
-        //println!("[{}] stop", tid);
-        break 'main;
-      } else {
-        for victim_tid in tids {
-          if *victim_tid != tid {
-            if let Some((new_cont, new_host)) = heap.vstk[*victim_tid].steal() {
-              cont = new_cont;
-              host = new_host;
-              //println!("stolen");
-              continue 'main;
+      State::Steal => {
+        //println!("[{}] steal", tid);
+        if stop.load(Ordering::Relaxed) {
+          //println!("[{}] stop", tid);
+          break 'main;
+        } else {
+          for victim_tid in tids {
+            if *victim_tid != tid {
+              if let Some((new_cont, new_host)) = heap.vstk[*victim_tid].steal() {
+                cont = new_cont;
+                host = new_host;
+                //println!("stolen");
+              goto!(Init);
+              }
             }
           }
+          bkoff.snooze();
+          //println!("[{}] continue stealing", tid);
+          goto!(Steal);
         }
-        bkoff.snooze();
-        //println!("[{}] continue stealing", tid);
-        continue 'steal;
       }
     }
   }


### PR DESCRIPTION
This is an update on PR #164. I've been able to write a version that runs almost as fast as your original by having the loop `continue` early after the state transitions. Here are some benchmark results:

<details>
<summary>Original using nested loops:</summary>

```
   Compiling main v1.0.0-beta (/home/.shared/repositories/github/nothingnesses/LambdaVM-Rust/bench/work/main)
    Finished release [optimized] target(s) in 1m 39s
HVM-1 | sort/bitonic | 1 | 0.233s
HVM-1 | sort/bitonic | 2 | 0.253s
HVM-1 | sort/bitonic | 3 | 0.251s
HVM-1 | sort/bitonic | 4 | 0.251s
HVM-1 | sort/bitonic | 5 | 0.243s
HVM-1 | sort/bitonic | 6 | 0.245s
HVM-1 | sort/bitonic | 7 | 0.243s
HVM-1 | sort/bitonic | 8 | 0.245s
HVM-1 | sort/bitonic | 9 | 0.255s
HVM-1 | sort/bitonic | 10 | 0.271s
HVM-1 | sort/bitonic | 11 | 0.315s
HVM-1 | sort/bitonic | 12 | 0.408s
HVM-1 | sort/bitonic | 13 | 0.629s
HVM-1 | sort/bitonic | 14 | 1.139s
HVM-1 | sort/bitonic | 15 | 2.327s
HVM-1 | sort/bitonic | 16 | 4.833s
HVM-1 | sort/bitonic | 17 | 9.129s
HVM-1 | sort/bitonic | 18 | 17.135s
HVM-1 | sort/bitonic | 19 | 35.380s
HVM-1 | sort/bitonic | 20 | 73.806s
HVM-1 | sort/bitonic | 21 | 161.132s
   Compiling main v1.0.0-beta (/home/.shared/repositories/github/nothingnesses/LambdaVM-Rust/bench/work/main)
    Finished release [optimized] target(s) in 34.05s
HVM-1 | sort/bubble | 12 | 1.770s
HVM-1 | sort/bubble | 13 | 6.299s
HVM-1 | sort/bubble | 14 | 17.508s
HVM-1 | sort/bubble | 15 | 59.821s
   Compiling main v1.0.0-beta (/home/.shared/repositories/github/nothingnesses/LambdaVM-Rust/bench/work/main)
    Finished release [optimized] target(s) in 18.70s
HVM-1 | sort/quick | 1 | 0.243s
HVM-1 | sort/quick | 2 | 0.253s
HVM-1 | sort/quick | 3 | 0.253s
HVM-1 | sort/quick | 4 | 0.242s
HVM-1 | sort/quick | 5 | 0.242s
HVM-1 | sort/quick | 6 | 0.243s
HVM-1 | sort/quick | 7 | 0.245s
HVM-1 | sort/quick | 8 | 0.245s
HVM-1 | sort/quick | 9 | 0.247s
HVM-1 | sort/quick | 10 | 0.256s
HVM-1 | sort/quick | 11 | 0.271s
HVM-1 | sort/quick | 12 | 0.407s
HVM-1 | sort/quick | 13 | 0.397s
HVM-1 | sort/quick | 14 | 0.543s
HVM-1 | sort/quick | 15 | 0.881s
HVM-1 | sort/quick | 16 | 1.624s
HVM-1 | sort/quick | 17 | 3.079s
HVM-1 | sort/quick | 18 | 6.136s
HVM-1 | sort/quick | 19 | 11.005s
HVM-1 | sort/quick | 20 | 20.922s
HVM-1 | sort/quick | 21 | 39.926s
   Compiling main v1.0.0-beta (/home/.shared/repositories/github/nothingnesses/LambdaVM-Rust/bench/work/main)
    Finished release [optimized] target(s) in 19.87s
HVM-1 | sort/radix | 1 | 0.230s
HVM-1 | sort/radix | 2 | 0.242s
HVM-1 | sort/radix | 3 | 0.236s
HVM-1 | sort/radix | 4 | 0.230s
HVM-1 | sort/radix | 5 | 0.252s
HVM-1 | sort/radix | 6 | 0.249s
HVM-1 | sort/radix | 7 | 0.251s
HVM-1 | sort/radix | 8 | 0.257s
HVM-1 | sort/radix | 9 | 0.250s
HVM-1 | sort/radix | 10 | 0.284s
HVM-1 | sort/radix | 11 | 0.326s
HVM-1 | sort/radix | 12 | 0.383s
HVM-1 | sort/radix | 13 | 0.428s
HVM-1 | sort/radix | 14 | 0.615s
HVM-1 | sort/radix | 15 | 0.991s
HVM-1 | sort/radix | 16 | 1.732s
HVM-1 | sort/radix | 17 | 3.209s
HVM-1 | sort/radix | 18 | 5.994s
HVM-1 | sort/radix | 19 | 11.176s
HVM-1 | sort/radix | 20 | 21.209s
HVM-1 | sort/radix | 21 | 52.724s
```
</details>


<details>
<summary>This version using `State` enum and early `continue`:</summary>

```
   Compiling main v1.0.0-beta (/home/.shared/repositories/github/nothingnesses/LambdaVM-Rust/bench/work/main)
    Finished release [optimized] target(s) in 1m 36s
HVM-1 | sort/bitonic | 1 | 0.244s
HVM-1 | sort/bitonic | 2 | 0.244s
HVM-1 | sort/bitonic | 3 | 0.226s
HVM-1 | sort/bitonic | 4 | 0.242s
HVM-1 | sort/bitonic | 5 | 0.227s
HVM-1 | sort/bitonic | 6 | 0.252s
HVM-1 | sort/bitonic | 7 | 0.248s
HVM-1 | sort/bitonic | 8 | 0.249s
HVM-1 | sort/bitonic | 9 | 0.257s
HVM-1 | sort/bitonic | 10 | 0.275s
HVM-1 | sort/bitonic | 11 | 0.314s
HVM-1 | sort/bitonic | 12 | 0.413s
HVM-1 | sort/bitonic | 13 | 0.659s
HVM-1 | sort/bitonic | 14 | 1.174s
HVM-1 | sort/bitonic | 15 | 2.436s
HVM-1 | sort/bitonic | 16 | 5.070s
HVM-1 | sort/bitonic | 17 | 9.389s
HVM-1 | sort/bitonic | 18 | 17.403s
HVM-1 | sort/bitonic | 19 | 37.178s
HVM-1 | sort/bitonic | 20 | 75.074s
HVM-1 | sort/bitonic | 21 | 156.945s
    Blocking waiting for file lock on package cache
   Compiling main v1.0.0-beta (/home/.shared/repositories/github/nothingnesses/LambdaVM-Rust/bench/work/main)
    Finished release [optimized] target(s) in 43.74s
HVM-1 | sort/bubble | 12 | 1.847s
HVM-1 | sort/bubble | 13 | 6.414s
HVM-1 | sort/bubble | 14 | 17.454s
HVM-1 | sort/bubble | 15 | 61.510s
   Compiling main v1.0.0-beta (/home/.shared/repositories/github/nothingnesses/LambdaVM-Rust/bench/work/main)
    Finished release [optimized] target(s) in 22.58s
HVM-1 | sort/quick | 1 | 0.273s
HVM-1 | sort/quick | 2 | 0.262s
HVM-1 | sort/quick | 3 | 0.231s
HVM-1 | sort/quick | 4 | 0.246s
HVM-1 | sort/quick | 5 | 0.252s
HVM-1 | sort/quick | 6 | 0.258s
HVM-1 | sort/quick | 7 | 0.241s
HVM-1 | sort/quick | 8 | 0.252s
HVM-1 | sort/quick | 9 | 0.250s
HVM-1 | sort/quick | 10 | 0.271s
HVM-1 | sort/quick | 11 | 0.446s
HVM-1 | sort/quick | 12 | 0.348s
HVM-1 | sort/quick | 13 | 0.413s
HVM-1 | sort/quick | 14 | 0.587s
HVM-1 | sort/quick | 15 | 0.926s
HVM-1 | sort/quick | 16 | 1.688s
HVM-1 | sort/quick | 17 | 3.188s
HVM-1 | sort/quick | 18 | 6.656s
HVM-1 | sort/quick | 19 | 11.575s
HVM-1 | sort/quick | 20 | 21.244s
HVM-1 | sort/quick | 21 | 40.908s
   Compiling main v1.0.0-beta (/home/.shared/repositories/github/nothingnesses/LambdaVM-Rust/bench/work/main)
    Finished release [optimized] target(s) in 20.21s
HVM-1 | sort/radix | 1 | 0.277s
HVM-1 | sort/radix | 2 | 0.241s
HVM-1 | sort/radix | 3 | 0.250s
HVM-1 | sort/radix | 4 | 0.253s
HVM-1 | sort/radix | 5 | 0.233s
HVM-1 | sort/radix | 6 | 0.252s
HVM-1 | sort/radix | 7 | 0.233s
HVM-1 | sort/radix | 8 | 0.261s
HVM-1 | sort/radix | 9 | 0.268s
HVM-1 | sort/radix | 10 | 0.274s
HVM-1 | sort/radix | 11 | 0.313s
HVM-1 | sort/radix | 12 | 0.360s
HVM-1 | sort/radix | 13 | 0.461s
HVM-1 | sort/radix | 14 | 0.667s
HVM-1 | sort/radix | 15 | 1.058s
HVM-1 | sort/radix | 16 | 1.832s
HVM-1 | sort/radix | 17 | 3.387s
HVM-1 | sort/radix | 18 | 6.515s
HVM-1 | sort/radix | 19 | 12.192s
HVM-1 | sort/radix | 20 | 22.566s
HVM-1 | sort/radix | 21 | 56.596s
```
</details>

Unfortunately, the versions I wrote that use the `State` enum segfault randomly when using more than one thread, which your original didn't do. I think it's strange though, because, as far as I can tell, this should be using the same algorithm as the original, except that it makes the states and transitions explicit, right? Or have I missed something?

The segfaults don't occur if I run with the debug flag that show the reduction steps. With the flag, changing the number of threads used doesn't noticeably change the time it takes to run, so I'm guessing that's probably just because running with the flag probably causes it to run in a single threaded fashion.

GDB shows me that the segfaults occur at line [158](https://github.com/nothingnesses/LambdaVM-Rust/blob/6d43c06d3afe92aea17dd9c01d940de08607acb5/src/runtime/base/reducer.rs#L158), when `load_ptr` is called and `state` is `Apply`. Changing the call to `get_unchecked` to `get` in `load_ptr` shows that it occurs when `loc` is `4294967295`.