### PR TITLE
Add exit(1) if a command failed

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -66,6 +66,7 @@ enum Command {
 fn main() {
   if let Err(err) = run_cli() {
     eprintln!("{}", err);
+    std::process::exit(1);
   };
 }
 


### PR DESCRIPTION
I'm not a Rust dev but this did the trick 😁 
This helped me chain commands in Bash scripts, eg. `hvm run -f "${MAIN_HVM}" && echo "Finished"` etc.