### PR TITLE
Fixed U60 and F60 precomp arity

### DIFF
--- a/src/runtime/base/precomp.rs
+++ b/src/runtime/base/precomp.rs
@@ -172,13 +172,13 @@ pub const PRECOMP : &[Precomp] = &[
   Precomp {
     id: KIND_TERM_U60,
     name: "Kind.Term.u60",
-    smap: &[false; 2],
+    smap: &[false; 1],
     funs: None,
   },
   Precomp {
     id: KIND_TERM_F60,
     name: "Kind.Term.f60",
-    smap: &[false; 2],
+    smap: &[false; 1],
     funs: None,
   },
   Precomp {


### PR DESCRIPTION
Fixed arity of both constructors that are types and not numbers. In the kind2 type checker the `Kind.Term.num` is the term that stores a U60 number so we will probably have to create a `Kind.Term.float` or something similar.