### PR TITLE
fix reducer 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -226,7 +226,7 @@ checksum = "809e18805660d7b6b2e2b9f316a5099521b5998d5cba4dda11b5157a21aaef03"
 
 [[package]]
 name = "hvm"
-version = "1.0.11-beta"
+version = "1.0.12-beta"
 dependencies = [
  "backtrace",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hvm"
-version = "1.0.11-beta"
+version = "1.0.12-beta"
 edition = "2021"
 description = "A massively parallel functional runtime."
 repository = "https://github.com/Kindelia/HVM"

--- a/src/runtime/base/reducer.rs
+++ b/src/runtime/base/reducer.rs
@@ -58,7 +58,7 @@ pub fn reduce(heap: &Heap, prog: &Program, tids: &[usize], root: u64, debug: boo
   });
 
   // Return whnf term ptr
-  return load_ptr(heap, root);
+  load_ptr(heap, root)
 }
 
 pub fn reducer(heap: &Heap, prog: &Program, tids: &[usize], stop: &AtomicBool, root: u64, tid: usize, debug: bool) {
@@ -106,7 +106,7 @@ pub fn reducer(heap: &Heap, prog: &Program, tids: &[usize], stop: &AtomicBool, r
               match acquire_lock(heap, tid, term) {
                 Err(locker_tid) => {
                   delay.push(new_visit(host, hold, cont));
-                  break 'work;
+                  continue 'work;
                 }
                 Ok(_) => {
                   // If the term changed, release lock and try again
@@ -241,12 +241,12 @@ pub fn reducer(heap: &Heap, prog: &Program, tids: &[usize], stop: &AtomicBool, r
           continue 'main;
         }
         // If available, visit a delayed location
-        else if delay.len() > 0 {
-          for next in delay.drain(0..).rev() {
-            visit.push(next);
-          }
-          continue 'blink;
-        }
+        // else if delay.len() > 0 {
+        //   for next in delay.drain(0..).rev() {
+        //     visit.push(next);
+        //   }
+        //   continue 'blink;
+        // }
         // Otherwise, we have nothing to do
         else {
           break 'blink;
@@ -370,7 +370,7 @@ pub fn normal(heap: &Heap, prog: &Program, tids: &[usize], host: u64, seen: &mut
 pub fn normalize(heap: &Heap, prog: &Program, tids: &[usize], host: u64, debug: bool) -> Ptr {
   let mut cost = get_cost(heap);
   loop {
-    normal(&heap, prog, tids, host, &mut im::HashSet::new(), debug);
+    normal(heap, prog, tids, host, &mut im::HashSet::new(), debug);
     let new_cost = get_cost(heap);
     if new_cost != cost {
       cost = new_cost;


### PR DESCRIPTION
Previously this code did not run in version 1.0.5-beta.
```
(Fib 0 x0 x1) = x0
(Fib i x0 x1) = (Fib (- i 1) x1 (+ x0 x1))

(Main n) = (Fib 500000 0 1)
```
and this one in version greater than 1.0.5-beta.

```
(Head (Cons x xs)) = (Some x)
(Head Nil) = None

(UnwrapOr (Some x) y) = x
(UnwrapOr None y) = y

(SumFirstTwo Nil) = 0 
(SumFirstTwo (Cons x xs)) = (+ x (UnwrapOr (Head xs) 0))

(Iter f x 0) = x
(Iter f x n) = (f (Iter f x (- n 1)))

(Fib n) = (Head (Iter λxs (Cons (SumFirstTwo xs) xs) (Cons 0 (Cons 1 Nil)) n))

(Main n) = (Fib 10000)
```
Now with these changes both programs are working perfectly, without loss of performance...