### PR TITLE
fix reduce

### DIFF
--- a/src/runtime/base/reducer.rs
+++ b/src/runtime/base/reducer.rs
@@ -122,7 +122,7 @@ pub fn reducer(
             DP0 | DP1 => {
               match acquire_lock(heap, tid, term) {
                 Err(locker_tid) => {
-                  break 'work;
+                  continue 'work;
                 }
                 Ok(_) => {
                   // If the term changed, release lock and try again


### PR DESCRIPTION
Previously this code did not run in version 1.0.5-beta.

(Fib 0 x0 x1) = x0
(Fib i x0 x1) = (Fib (- i 1) x1 (+ x0 x1))

(Main n) = (Fib 500000 0 1)
and this one in version greater than 1.0.5-beta.

(Head (Cons x xs)) = (Some x)
(Head Nil) = None

(UnwrapOr (Some x) y) = x
(UnwrapOr None y) = y

(SumFirstTwo Nil) = 0 
(SumFirstTwo (Cons x xs)) = (+ x (UnwrapOr (Head xs) 0))

(Iter f x 0) = x
(Iter f x n) = (f (Iter f x (- n 1)))

(Fib n) = (Head (Iter λxs (Cons (SumFirstTwo xs) xs) (Cons 0 (Cons 1 Nil)) n))

(Main n) = (Fib 10000)
Now with these changes both programs are working perfectly, without loss of performance...