### PR TITLE
Address #185

### DIFF
--- a/src/compiler/mod.rs
+++ b/src/compiler/mod.rs
@@ -12,6 +12,7 @@ pub fn compile(code: &str, name: &str) -> std::io::Result<()> {
   // hvm
   std::fs::create_dir(format!("./{}",name)).ok();
   std::fs::write(format!("./{}/Cargo.toml",name), cargo_rs)?;
+  std::fs::write(format!("./{}/rust-toolchain.toml",name), include_str!("./../../rust-toolchain.toml"))?;
 
   // hvm/src
   std::fs::create_dir(format!("./{}/src",name)).ok();


### PR DESCRIPTION
This adds rust-toolchain.toml to HVM compilation outputs so cargo should be able to compile them successfully, which should fix #185 . I also changed flake.nix to use nix-filter so it only includes the files that are actually used in the derivation, to make them smaller.