### PR TITLE
Speed up default_heap_size

### DIFF
--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -8,7 +8,7 @@ pub mod base;
 pub mod data;
 pub mod rule;
 
-use sysinfo::{System, SystemExt};
+use sysinfo::{System, SystemExt, RefreshKind};
 
 pub use base::{*};
 pub use data::{*};
@@ -23,8 +23,7 @@ pub const CELLS_PER_GB: usize = 0x8000000;
 // If unspecified, allocates `max(16 GB, 75% free_sys_mem)` memory
 pub fn default_heap_size() -> usize {
   use sysinfo::SystemExt;
-  let system = System::new_all();
-  let available_memory = system.free_memory();
+  let available_memory = System::new_with_specifics(RefreshKind::new().with_memory()).free_memory();
   let heap_size = (available_memory * 3 / 4) / 8;
   let heap_size = std::cmp::min(heap_size as usize, 16 * CELLS_PER_GB);
   return heap_size as usize;


### PR DESCRIPTION
`System::new_all` does a lot more than just measuring available mem, so let's cut those extra syscalls to make startup faster.

Bench (examples/hello):

Old:

```
$ hyperfine "target/release/main run '(Main 0)'"
Benchmark 1: target/release/main run '(Main 0)'
  Time (mean ± σ):     513.4 ms ±  36.6 ms    [User: 285.6 ms, System: 455.2 ms]
  Range (min … max):   469.5 ms … 587.2 ms    10 runs
```

New:

```
$ hyperfine "target/release/main run '(Main 0)'"
Benchmark 1: target/release/main run '(Main 0)'
  Time (mean ± σ):      77.5 ms ±   4.9 ms    [User: 18.0 ms, System: 59.9 ms]
  Range (min … max):    67.2 ms …  85.6 ms    33 runs
```