### PR TITLE
fix: fix `Runtime::new` and `Runtime::from_code_with`.

### DIFF
--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -51,7 +51,7 @@ impl Runtime {
       heap: new_heap(size, tids),
       prog: Program::new(),
       book: language::rulebook::new_rulebook(),
-      tids: new_tids(size),
+      tids: new_tids(tids),
       dbug: dbug,
     }
   }
@@ -62,7 +62,7 @@ impl Runtime {
     let heap = new_heap(size, tids);
     let prog = Program::new();
     let book = language::rulebook::gen_rulebook(&file);
-    let tids = new_tids(size);
+    let tids = new_tids(tids);
     return Ok(Runtime { heap, prog, book, tids, dbug });
   }
 


### PR DESCRIPTION
Runtime creation was either panicking or getting killed by the system because it was creating as many threads as the heap size, instead of reading the thread count variable.