### PR TITLE
chore: update Cargo.lock.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -217,7 +217,7 @@ checksum = "809e18805660d7b6b2e2b9f316a5099521b5998d5cba4dda11b5157a21aaef03"
 
 [[package]]
 name = "hvm"
-version = "1.0.20-beta"
+version = "1.0.0"
 dependencies = [
  "backtrace",
  "clap",


### PR DESCRIPTION
The lockfile was not up-to-date with the current crate version.

As soon as you run `cargo build` it updates the Cargo.lock to match, but it'd be good to have it in sync with the current Cargo.toml.